### PR TITLE
bug fix for extract_data.F

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -142,7 +142,7 @@
 
         ! find fractional cdr fluxes for this subdomain
         allocate(dist(GLOBAL_2D_ARRAY)); dist = 1e6 ! Some large number so we don't get single-point releases in the halos
-        allocate(frac(GLOBAL_2D_ARRAY,ncdr))
+        allocate(frac(GLOBAL_2D_ARRAY,ncdr)); frac = 0
 
         cidx = 0
         do icdr= 1,ncdr


### PR DESCRIPTION
Added a fix to extract_data.F that solves a segfault problem with the GNU compiler.

Briefly, we need to initialize obj%scalar to false, otherwise spurious "true" values can creep in and send the code into a loop where it doesn't belong and where memory hasn't been allocated for certain data structures.