### PR TITLE
bug fix for cdr_frc.F

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -142,7 +142,7 @@
 
         ! find fractional cdr fluxes for this subdomain
         allocate(dist(GLOBAL_2D_ARRAY)); dist = 1e6 ! Some large number so we don't get single-point releases in the halos
-        allocate(frac(GLOBAL_2D_ARRAY,ncdr))
+        allocate(frac(GLOBAL_2D_ARRAY,ncdr)); frac = 0
 
         cidx = 0
         do icdr= 1,ncdr


### PR DESCRIPTION
Bug fix for the CDR forcing module, where we now initialize "frac" to zero so that it doesn't attempt to set forcing values at points where no CDR forcing exists.  Basically this fix prevents it from entering a loop where it shouldn't go.