### PR TITLE
A few bugfixes for monthly averages and restarts

### DIFF
--- a/src/basic_output.F
+++ b/src/basic_output.F
@@ -82,6 +82,7 @@
       public :: calc_avg_ocean_vars
       public :: wrt_rst_ocean_vars
       public :: init_avg_arrays
+      public :: init_restarts
 
       contains  !]
 !----------------------------------------------------------------------
@@ -92,8 +93,10 @@
       integer,dimension(6)   :: date
 
       if (wrt_file_rst .and. monthly_restarts) then
-          call sec2date(time,date)
-          prev_month = date(2)
+        ! Look one timestep ahead to initialize the "previous month", so that
+        ! when we restart we don't immediately write out a file.
+        call sec2date(start_time+dt,date)
+        prev_month = date(2)
       endif
 
       end subroutine init_restarts !]
@@ -495,14 +498,19 @@
           ! new month.
           ! time + 2*dt here so that it looks two timesteps ahead to see if we're changing months.
           call sec2date(time+2*dt,date)
-          if ((date(2) - prev_month) /= 0) then
-            call wrt_restart_file
-            write_another_step = .true.
-          endif
+
+      if (mynode == 0) then
+      print *, "currmonth", date(2)
+      endif
 
           if (write_another_step) then
             call wrt_restart_file
             write_another_step = .false.
+          endif
+
+          if ((date(2) - prev_month) /= 0) then
+            call wrt_restart_file
+            write_another_step = .true.
           endif
 
           prev_month = date(2)

--- a/src/cstar_output.F
+++ b/src/cstar_output.F
@@ -91,8 +91,10 @@
          error stop 'ERROR: cstar_output:: monthly avgs=t, but do_avg=f'
       endif
 
+      ! Look one timestep ahead to initialize the "previous month", so that
+      ! when we restart we don't immediately write out a file.
       if (monthly_averages) then
-          call sec2date(time,date)
+          call sec2date(time+dt,date)
           prev_month = date(2)
       endif
 

--- a/src/main.F
+++ b/src/main.F
@@ -237,6 +237,8 @@ CR      write(*,*) ' -6' MYID
 #endif
         call get_init(nrrec, 1)
 
+        call init_restarts
+
 #ifdef ANA_INITIAL
       endif    !<-- nrrec>0
 #endif


### PR DESCRIPTION
Fixed a bug that was causing a new file to be written immediately upon restart.
Fixed another bug that was causing the restart file to write the same timestep twice.
Added a call to init_restarts in main.F.