### PR TITLE
Bug fix:  increase to max_options_string (roms_read_write.F)

### DIFF
--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -80,7 +80,7 @@
       integer :: nxc,nyc
       real,dimension(:,:),allocatable   :: cdata     ! Array to read in coarse surface forcing data
 
-      integer,parameter :: max_options_string=2000
+      integer,parameter :: max_options_string=20000
 
       ! option string to go into output file attributes
 


### PR DESCRIPTION
Increased size of max_options_string to allow us to run with a lot of input files without the model terminating.