### PR TITLE
Remove normalization of "frac" in cdr_frc.F

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -111,7 +111,7 @@
 
       ! local
       integer :: ierr,ncid,i,j,k
-      real :: norm,vint,arg
+      real :: vint,arg
       real :: local_int,global_int
       real, dimension(nz) :: arg_nz
       real :: local_min_val
@@ -184,10 +184,10 @@
           else
 
 !           close  = max(3*cdr_hsc(icdr),dx)
-            norm = pi*cdr_hsc(icdr)*cdr_hsc(icdr) ! 2d integral of exp(-(dist/hscl)^2 )
+!            norm = pi*cdr_hsc(icdr)*cdr_hsc(icdr) ! 2d integral of exp(-(dist/hscl)^2 )
             call ll2dist(lonr,latr,cdr_lon(icdr),cdr_lat(icdr),dist);
             frac(:,:,icdr) = exp(-(dist/cdr_hsc(icdr))**2)
-            frac(:,:,icdr) = frac(:,:,icdr)/pm/pn/norm
+!            frac(:,:,icdr) = frac(:,:,icdr)/pm/pn/norm
             do j=1,ny
               do i=1,nx
 !               if (dist(i,j)<close.and.rmask(i,j)>0) then


### PR DESCRIPTION
The normalization of the "frac" variable was leading to horizontal Gaussian profiles that were being cut off in undesirable ways due to the "frac > 1e-3" threshold.  Testing in ROMS-Tools showed that it may be more desirable to remove normalization entirely, which is what this commit does.