### PR TITLE
Bugfix for set_frc_data skipping forcing times.

### DIFF
--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -323,7 +323,7 @@
         ! and we will read in the greatest irec that is less than (new irec)
         if (irec_stride > 1) then
 
-          if (ifile_stride == 0) then
+          if ((ifile_stride == 0) .or. (nc%irec>2)) then
             nc%irec = nc%irec-2
           else
             nc%ifile = nc%ifile-1
@@ -401,7 +401,7 @@
         ! and we will read in the greatest irec that is less than (new irec)
         if (irec_stride > 1) then
 
-          if (ifile_stride == 0) then
+          if ((ifile_stride == 0) .or. (nc%irec>2)) then
             nc%irec = nc%irec-2
           else
             nc%ifile = nc%ifile-1
@@ -476,7 +476,7 @@
         ! and we will read in the greatest irec that is less than (new irec)
         if (irec_stride > 1) then
 
-          if (ifile_stride == 0) then
+          if ((ifile_stride == 0) .or. (nc%irec>2)) then
             nc%irec = nc%irec-2
           else
             nc%ifile = nc%ifile-1


### PR DESCRIPTION
    This commit fixes a bug that was found in set_frc_data --> roms_read_write.F,
    where if there are records inside the forcing file(s) with timestamps at
    higher frequency than dt, ROMS would silently skip over those records. The result
    was that ROMS would interpolate the forcing between timestamp (X) and timestamp (X+n),
    even though the closest forcing data less than the current model time was at timestamp
    (X+n-1).

Closes Issue #1 