### PR TITLE
Added handler for very small cdr_hsc in CDR forcing module.

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -120,6 +120,7 @@
       real, dimension(2) :: global_minloc
       real,dimension(:,:)  ,allocatable :: dist
       real,dimension(:,:,:),allocatable :: frac
+      integer :: cidx_start
 
       call init_arrays_cdr
 
@@ -145,46 +146,51 @@
         allocate(frac(GLOBAL_2D_ARRAY,ncdr)); frac = 0
 
         cidx = 0
+        cidx_start = 0
         do icdr= 1,ncdr
 
-          if (cdr_hsc(icdr) == 0) then
-            call ll2dist(lonr,latr,cdr_lon(icdr),cdr_lat(icdr),dist);
+          call ll2dist(lonr,latr,cdr_lon(icdr),cdr_lat(icdr),dist);
 
-            local_min_val = MINVAL(dist)
-            ! Find local index that is closest to release location
-            lmi = MINLOC(dist)
-            ! Adjust index to account for the fact that GLOBAL_ARRAY does not start at index 1
-            lmi(:) = lmi(:) + lbound(dist) - 1
+          local_min_val = MINVAL(dist)
+          ! Find local index that is closest to release location
+          lmi = MINLOC(dist)
+          ! Adjust index to account for the fact that GLOBAL_ARRAY does not start at index 1
+          lmi(:) = lmi(:) + lbound(dist) - 1
 
-            ! Pack local minimum and MPI rank into a vector
-            local_minloc(1) = local_min_val
-            local_minloc(2) = mynode
+          ! Pack local minimum and MPI rank into a vector
+          local_minloc(1) = local_min_val
+          local_minloc(2) = mynode
 
-            ! Find global minimum and rank where the minimum occurs
-            call MPI_Reduce( local_minloc, global_minloc, 2, mpi_2double_precision,
-     &      mpi_minloc, 0, ocean_grid_comm, ierr)
+          ! Find global minimum and rank where the minimum occurs
+          call MPI_Reduce( local_minloc, global_minloc, 2, mpi_2double_precision,
+     &    mpi_minloc, 0, ocean_grid_comm, ierr)
 
-            ! Broadcast rank where minimum occurs to all processes
-            call MPI_Bcast(global_minloc, 2,mpi_double_precision,0,ocean_grid_comm,ierr)
+          ! Broadcast rank where minimum occurs to all processes
+          call MPI_Bcast(global_minloc, 2,mpi_double_precision,0,ocean_grid_comm,ierr)
 
-            if (mynode == global_minloc(2)) then
-              print *, 'The minimum distance to single-point Release', icdr, 'is', global_minloc(1)
-              print *, 'This is on rank:', mynode
-              print *, 'at point', lmi
-              print *, 'The intended release location was Lon:', cdr_lon(icdr), 'Lat:', cdr_lat(icdr)
-              print *, 'The release will take place at Lon:', lonr(lmi(1),lmi(2)), 'Lat:', latr(lmi(1),lmi(2))
-              if (rmask(lmi(1),lmi(2))==0) then
-                error stop 'ERROR: single-point CDR release requested on a land point'
-              else
-                frac(lmi(1),lmi(2),icdr) = 1
-                cidx = cidx+1
-              endif
+          if (mynode == global_minloc(2)) then
+            print *, 'The minimum distance to Release', icdr, 'is', global_minloc(1)
+            print *, 'This is on rank:', mynode
+            print *, 'at point', lmi
+            print *, 'The intended release location was Lon:', cdr_lon(icdr), 'Lat:', cdr_lat(icdr)
+            print *, 'The release will take place at Lon:', lonr(lmi(1),lmi(2)), 'Lat:', latr(lmi(1),lmi(2))
+            if ((rmask(lmi(1),lmi(2))==0) .and. (cdr_hsc(icdr) == 0)) then
+              error stop 'ERROR: single-point CDR release requested on a land point'
             endif
+          endif
 
+
+          ! Handler for single-point release
+          if (cdr_hsc(icdr) == 0) then
+            if (mynode == global_minloc(2)) then
+              frac(lmi(1),lmi(2),icdr) = 1
+              cidx = cidx+1
+            endif
+          ! Handler for nonzero hscl
           else
-
             call ll2dist(lonr,latr,cdr_lon(icdr),cdr_lat(icdr),dist);
             frac(:,:,icdr) = exp(-(dist/cdr_hsc(icdr))**2)
+
             do j=1,ny
               do i=1,nx
                 if (frac(i,j,icdr) >1e-3.and.rmask(i,j)>0) then
@@ -192,7 +198,18 @@
                 endif
               enddo
             enddo
-          endif ! hscl = 0
+
+            ! Handler for really small values of hscl
+            if (mynode == global_minloc(2)) then
+              if (cidx == cidx_start) then
+                frac(lmi(1),lmi(2),icdr) = 1
+                cidx = cidx+1
+              endif
+            endif
+
+          endif ! cdr_hsc(icdr) = 0
+          cidx_start = cidx
+
         enddo ! icdr
 
         cdr_nprf = cidx


### PR DESCRIPTION
Previously it was possible to have no CDR release in the model when the horizontal scale was set to be a really small nonzero value (significantly smaller than the gridscale), even though we had added a handler to deal with the most extreme case of hsc=0 (in which case the model would just find the nearest cell center). This commit unifies the logic for both of these cases, so that the CDR module always calculates the distance from the release location to the nearest cell center, and will place the release there whether hsc=0 or hsc is so small that no "significant" release points are close by. If hsc is large then the code will behave as before.