### PR TITLE
NHMG link bugfix

### DIFF
--- a/ci/print_compilation_logs.sh
+++ b/ci/print_compilation_logs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-#
+# 
 
 # Get the "Examples" array from Examples/code_check/do_test_all.sh
-{
-  IFS= read -r shebang_line
+{ 
+  IFS= read -r shebang_line 
   while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" == *"USER INPUT END"* ]] && break
     eval "$line"
-  done
+  done 
 } < $ROMS_ROOT/Examples/code_check/do_test_all.sh
 
 if [ ${#Examples[@]} -eq 0 ]; then
@@ -26,10 +26,10 @@ for example in "${Examples[@]}"; do
     echo "$example"
     echo "###############################################################################################"
     if [ -e "${ROMS_ROOT}/Examples/${example}/code_check/compile.log" ];then
-	cat ${ROMS_ROOT}/Examples/${example}/code_check/test_old.log
+	cat ${ROMS_ROOT}/Examples/${example}/code_check/compile.log
     fi
     if [ $example == "bgc_real" ];then
-
+	
        echo "------------------------------"
        echo "MARBL"
        echo "------------------------------"
@@ -43,6 +43,6 @@ for example in "${Examples[@]}"; do
 	   cat ${ROMS_ROOT}/Examples/${example}/code_check/compile_BEC.log
        fi
     fi
-
+       
     #ls ${ROMS_ROOT}/Examples/${example}/code_check/test_old.log
 done

--- a/ci/print_compilation_logs.sh
+++ b/ci/print_compilation_logs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-# 
+#
 
 # Get the "Examples" array from Examples/code_check/do_test_all.sh
-{ 
-  IFS= read -r shebang_line 
+{
+  IFS= read -r shebang_line
   while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" == *"USER INPUT END"* ]] && break
     eval "$line"
-  done 
+  done
 } < $ROMS_ROOT/Examples/code_check/do_test_all.sh
 
 if [ ${#Examples[@]} -eq 0 ]; then
@@ -29,7 +29,7 @@ for example in "${Examples[@]}"; do
 	cat ${ROMS_ROOT}/Examples/${example}/code_check/compile.log
     fi
     if [ $example == "bgc_real" ];then
-	
+
        echo "------------------------------"
        echo "MARBL"
        echo "------------------------------"
@@ -43,6 +43,6 @@ for example in "${Examples[@]}"; do
 	   cat ${ROMS_ROOT}/Examples/${example}/code_check/compile_BEC.log
        fi
     fi
-       
+
     #ls ${ROMS_ROOT}/Examples/${example}/code_check/test_old.log
 done

--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -96,9 +96,11 @@ else ifeq ($(BUILD_MODE),grof)
    KEEP_PPSRC=true
 endif
 
-#Check whether we're compiling with MARBL:
+#Check whether we're compiling with MARBL or NHMG:
 ifeq ($(wildcard cppdefs.opt),cppdefs.opt)
 	USEMARBL := $(shell grep -q '^[^!]*\#[[:space:]]*define[[:space:]]*MARBL' cppdefs.opt && echo true || echo false )
+	USENHMG :=  $(shell grep -q '^[^!]*\#[[:space:]]*define[[:space:]]*NHMG' cppdefs.opt && echo true || echo false )
+
 endif
 
 # C-preprocessor (cpp):
@@ -113,10 +115,6 @@ ifeq ($(COMPILER),intel)
 else
         CPP = /usr/bin/cpp
 	CPPFLAGS =  -traditional -D__IFC -I${MPIHOME}/include -I${NETCDFHOME}/include
-endif
-
-ifeq ($(USEMARBL),true)
-	CPPFLAGS+= -I${MARBL_ROOT}/include
 endif
 
 #   Since we no longer keep preprocessed files after compilation, if you want to still
@@ -204,13 +202,19 @@ ifeq ($(COMPILER),gnu)
 endif
 
 # Options to link to libraries & modules (NetCDF, etc):
-        LCDF = $(NHMG_LIB) $(NETCDFF_LIB) $(NETCDFC_LIB)
+        LCDF =  $(NETCDFF_LIB) $(NETCDFC_LIB)
 ifeq ($(USEMARBL),true)
 	LCDF += $(MARBL_LIB)
+endif
+ifeq ($(USENHMG),true)
+	LCDF += $(NHMG_LIB)
 endif
 	LCDF +=$(NETCDFF_INC) $(NETCDFC_INC)
 ifeq ($(USEMARBL),true)
 	LCDF += $(MARBL_INC)
+endif
+ifeq ($(USENHMG),true)
+	LCDF += $(NHMG_INC)
 endif
 
 

--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -127,7 +127,7 @@ endif
 # Path names (non-hydrostatic & NetCDF libraries):
 	NHMG_ROOT = $(ROMS_ROOT)/NHMG
 	NHMG_LIB  = -L$(NHMG_ROOT)/lib -lnhmg
-	NHMG_INC  = $(NHMG_ROOT)/include
+	NHMG_INC  = -I$(NHMG_ROOT)/include
 
 	VPATH = ${MPIHOME}/include:${NHMG_INC}
 	CPATH = ${MPIHOME}/include:${NHMG_INC}


### PR DESCRIPTION
This one got away for ages cos only about 3 people in the world use the NHMG library, but its `include` statement wasn't being added to the `make` flags. This PR makes it so `NHMG` is _conditionally_ linked based on the presence of the `NHMG` cpp key in `cppdefs.opt`, simultaneously solving the problem that compiling NHMG is an (unnecessary) requirement for all of the `Examples` cases and `Tools-Roms`. 