### PR TITLE
fix typo in cdr_frc.F leading to illegal MPI memory operation

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -162,7 +162,7 @@
           local_minloc(2) = mynode
 
           ! Find global minimum and rank where the minimum occurs
-          call MPI_Reduce( local_minloc, global_minloc, 2, mpi_2double_precision,
+          call MPI_Reduce( local_minloc, global_minloc, 1, mpi_2double_precision,
      &    mpi_minloc, 0, ocean_grid_comm, ierr)
 
           ! Broadcast rank where minimum occurs to all processes


### PR DESCRIPTION
in `MPI_Reduce( local_minloc, global_minloc, 2, mpi_2double_precision, mpi_minloc, 0, ocean_grid_comm, ierr)` the `2` should be a `1` as we have 1 pair (`mpi_2double_precision`) rather than 2 numbers.

This was triggering an error for me locally where MPI was attempting to copy between overlapping memory regions.