### PR TITLE
Removed normalization by Hz for cdr_prf.

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -246,7 +246,7 @@
                    vint = 0
                    do k=1,nz
                      arg = ( (z_r(i,j,k) + cdr_dep(icdr) )/cdr_vsc(icdr) )**2
-                     cdr_prf(cidx,k) = exp(-arg)*Hz(i,j,k)
+                     cdr_prf(cidx,k) = exp(-arg)
                    enddo
                    ! The 1D integral of exp^(z/cdr_vsc(icdr))**2 is cdr_vsc(icdr)*SQRT(pi),
                    ! so normalizing by this amount will ensure we don't weight the


### PR DESCRIPTION
In the CDR forcing module the vertical distribution of the forcing was being weighted by a multiplication by Hz, which was making the distribution of the tracer mass look weird when they were plotted. Removal of this multiplication made the distribution much more sensible, as it was no longer affected by cell thickness; now the amount of mass added to each cell is only affected by its distance from the release location.