### PR TITLE
use `max_name_size` parameter for 'fname'-related allocations

### DIFF
--- a/src/basic_output.F
+++ b/src/basic_output.F
@@ -72,7 +72,7 @@
       integer :: ncid=-1, prev_fill_mode
       real    :: t_avg_ovars=0
       integer :: navg_ovars = 0                             ! number of samples in average
-      character(len=99),public :: fname_rst                 ! restart filename needed by diagnostics
+      character(len=max_name_size),public :: fname_rst                 ! restart filename needed by diagnostics
       integer,public           :: rec_rst=nrpf_rst          ! current file output record needed by diags
       integer                :: month_at_prev_timestep
       logical                :: write_another_step = .false.
@@ -266,7 +266,7 @@
       integer,save           :: total_rec_his=0                      ! total his output records so far
       real,save              :: output_time_his=output_period_his+10
       logical,save           :: first_step=.true.
-      character(len=99),save :: fname_his
+      character(len=max_name_size),save :: fname_his
       integer                :: tile, ierr, i, j, k
       logical,save           :: supress=.false.
       logical                :: blowup,initial
@@ -400,7 +400,7 @@
       integer,save           :: total_rec_avg=0                      ! total avg output records so far
       real,save              :: output_time_avg=0                    ! time since last output
       logical,save           :: first_step=.true.
-      character(len=99),save :: fname_avg
+      character(len=max_name_size),save :: fname_avg
       character(len=99)      :: output_time_string
       character(len=99)      :: formatted_string
       integer :: tile, tn, ierr, k
@@ -644,7 +644,7 @@
       implicit none
 
       !input/output
-      character(len=99),intent(out) :: fname
+      character(len=max_name_size),intent(out) :: fname
       logical,          intent(in)  :: avg                 ! his or average file
 
       ! local
@@ -675,7 +675,7 @@
       implicit none
 
       !input/output
-      character(len=99),intent(out) :: fname
+      character(len=max_name_size),intent(out) :: fname
 
       ! local
       integer :: ierr,varid

--- a/src/read_inp.F
+++ b/src/read_inp.F
@@ -23,7 +23,7 @@
       integer ierr
 
       integer, parameter :: input=15, testunit=40,
-     &                  max_fname=256, max_kwsize=99
+     &                  max_fname=256, max_kwsize=256
       character(len=max_fname)  :: fname, force_string
       character(len=max_kwsize) :: keyword
       character(len=3), parameter :: end_signal='end'

--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -924,7 +924,6 @@
       call cancel_kwd (keyword(1:kwlen), ierr)             ! remove keyword from keyword list for read_inp.F
                                                            ! to know it's accounted for
       read(input,'(A)',err=95) output_root_name            ! read & save filename root
-
       goto 100
                                                            ! error for read(input,'(A)',err=95)
   95  write(*,'(/1x,4A/)') '### ERROR: roms_read_write :: Cannot ',


### PR DESCRIPTION
This parameter was largely unused and output file names were getting truncated to 99 chars.