### PR TITLE
CDR bugfixes 

### DIFF
--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -183,7 +183,8 @@ endif
 # Apply debug, strict, vtune, or grof settings for Intel compilers
 ifeq ($(COMPILER),$(filter ifort intel, $(COMPILER)))
     ifeq ($(BUILD_MODE),debug)
-        FFLAGS = -g -traceback -check all
+        FFLAGS = -O0 -g -traceback -check all
+        KEEP_PPSRC=true
     else ifeq ($(BUILD_MODE),strict)
         FFLAGS += -fp-model strict
     else ifeq ($(BUILD_MODE),vtune)
@@ -197,7 +198,8 @@ endif
 ifeq ($(COMPILER),gnu)
     FFLAGS = -O3 -fallow-argument-mismatch
     ifeq ($(BUILD_MODE),debug)
-        FFLAGS = -fallow-argument-mismatch -g -fbacktrace -fcheck=all
+         KEEP_PPSRC=true
+        FFLAGS = -O0 -fallow-argument-mismatch -g -fbacktrace -fcheck=all
     endif
 endif
 

--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -183,8 +183,7 @@ endif
 # Apply debug, strict, vtune, or grof settings for Intel compilers
 ifeq ($(COMPILER),$(filter ifort intel, $(COMPILER)))
     ifeq ($(BUILD_MODE),debug)
-        FFLAGS = -O0 -g -traceback -check all
-        KEEP_PPSRC=true
+        FFLAGS = -g -traceback -check all
     else ifeq ($(BUILD_MODE),strict)
         FFLAGS += -fp-model strict
     else ifeq ($(BUILD_MODE),vtune)
@@ -198,8 +197,7 @@ endif
 ifeq ($(COMPILER),gnu)
     FFLAGS = -O3 -fallow-argument-mismatch
     ifeq ($(BUILD_MODE),debug)
-         KEEP_PPSRC=true
-        FFLAGS = -O0 -fallow-argument-mismatch -g -fbacktrace -fcheck=all
+        FFLAGS = -fallow-argument-mismatch -g -fbacktrace -fcheck=all
     endif
 endif
 

--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -208,10 +208,10 @@
      &         (rmask(lmi(1),lmi(2))==0)) then
              bad_releases(icdr) = .true.
           end if
-          
+
           cidx_start = cidx
        enddo                    ! icdr
-       
+
 ! Report any releases on land and stop
        call MPI_Allreduce(MPI_IN_PLACE, bad_releases, ncdr, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierr)
 
@@ -223,11 +223,11 @@
              print *, "(Note 1-indexing):",
      &            pack([(i,i=1,ncdr)], bad_releases)
              print *, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-             call MPI_Abort(MPI_COMM_WORLD, 1, ierr)             
+             call MPI_Abort(MPI_COMM_WORLD, 1, ierr)
           end if
           call MPI_Barrier(MPI_COMM_WORLD, ierr)
        end if
-            
+
 
         cdr_nprf = cidx
 

--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -109,6 +109,7 @@
 
       ! local
       integer :: ierr,ncid,i,j,k, icdr, cidx, cidx_start
+      logical, dimension(ncdr)  :: bad_releases
       integer, dimension(2) :: lmi
       real :: vint,arg
       real :: local_int,global_int
@@ -119,7 +120,7 @@
       real,dimension(:,:)  ,allocatable :: dist
       real,dimension(:,:,:),allocatable :: frac
 
-
+      bad_releases(:) = .false.
       call init_arrays_cdr
 
       if (cdr_analytical) then
@@ -173,10 +174,6 @@
             print *, 'at point', lmi
             print *, 'The intended release location was Lon:', cdr_lon(icdr), 'Lat:', cdr_lat(icdr)
             print *, 'The release will take place at Lon:', lonr(lmi(1),lmi(2)), 'Lat:', latr(lmi(1),lmi(2))
-c$$$            if ((rmask(lmi(1),lmi(2))==0) .and. (cdr_hsc(icdr) == 0)) then
-c$$$              error stop
-c$$$     &           'ERROR: point CDR release requested on a land point'
-c$$$            endif
           endif
 
 
@@ -205,30 +202,41 @@ c$$$            endif
                 frac(lmi(1),lmi(2),icdr) = 1
                 cidx = cidx+1
               endif
-            endif
-            if (frac(lmi(1),lmi(2),icdr) ==1 ) then
-               if (rmask(lmi(1),lmi(2))==0) then
-                  print *, "release on dry point", icdr
-               elseif (rmask(lmi(1),lmi(2))==1) then
-                  print *, "release on wet point", icdr
-               end if
-            end if
-
-
-c$$$            end if
-c$$$            if ((rmask(lmi(1),lmi(2))==0) .and.
-c$$$     &           (frac(lmi(1),lmi(2),icdr) == 1)) then
-c$$$               print *, 'release on land:', icdr
-c$$$              !error stop 'ERROR: CDR release is on land.'
-c$$$            elseif (frac(lmi(1),lmi(2),icdr)==1) then
-c$$$               print *, 'release at sea', icdr
-c$$$            endif
-
-
+           endif
           endif ! cdr_hsc(icdr) = 0
-          cidx_start = cidx
 
-        enddo ! icdr
+          ! Check for releases on land
+          if ((frac(lmi(1),lmi(2),icdr) ==1 ) .and.
+     &         (rmask(lmi(1),lmi(2))==0)) then
+             bad_releases(icdr) = .true.
+          end if
+          
+          cidx_start = cidx
+       enddo                    ! icdr
+       
+! Report any releases on land and stop
+       call MPI_Allreduce(MPI_IN_PLACE, bad_releases, ncdr, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierr)
+
+!     Now every rank has the same bad_releases array
+       if (any(bad_releases)) then
+          if (mynode == 0) then
+             print *, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+             print *, "ERROR: the following CDR releases are on land"
+             print *, "(Note 1-indexing):",
+     &            pack([(i,i=1,ncdr)], bad_releases)
+             print *, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+             call MPI_Abort(MPI_COMM_WORLD, 1, ierr)             
+          end if
+          call MPI_Barrier(MPI_COMM_WORLD, ierr)
+       end if
+c$$$       if (any(bad_releases)) then
+c$$$          
+c$$$          print *, "ERROR the following CDR releases are on land",
+c$$$     &            pack([(i,i=1,ncdr)], bad_releases)
+c$$$          error stop
+c$$$       end if
+
+            
 
         cdr_nprf = cidx
 

--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -32,9 +32,7 @@
       real   ,public,allocatable,dimension(:,:) :: cdr_prf      ! cdr fractions
       integer,public,allocatable,dimension(:)   :: cdr_iloc     ! cdr local i location
       integer,public,allocatable,dimension(:)   :: cdr_jloc     ! cdr local j location
-      real   ,public,allocatable,dimension(:)   :: cdr_icdr     ! cdr release number
-
-      integer,public  :: icdr,cidx !   index for looping through cdr locations
+      integer,public,allocatable,dimension(:)   :: cdr_icdr     ! cdr release number
 
       real,public,dimension(ncdr)           :: cdr_vol      ! cdr volume
       real,public,dimension(ncdr,nt)        :: cdr_flx      ! cdr tracer flux
@@ -70,7 +68,7 @@
       implicit none
 
       ! local
-      integer :: i,j
+      integer :: i,j, icdr
 
       if (.not. init_cdr_done) call init_cdr_frc
 
@@ -110,17 +108,17 @@
       implicit none
 
       ! local
-      integer :: ierr,ncid,i,j,k
+      integer :: ierr,ncid,i,j,k, icdr, cidx, cidx_start
+      integer, dimension(2) :: lmi
       real :: vint,arg
       real :: local_int,global_int
       real, dimension(nz) :: arg_nz
       real :: local_min_val
-      integer, dimension(2) :: lmi
       real, dimension(2) :: local_minloc
       real, dimension(2) :: global_minloc
       real,dimension(:,:)  ,allocatable :: dist
       real,dimension(:,:,:),allocatable :: frac
-      integer :: cidx_start
+
 
       call init_arrays_cdr
 
@@ -132,7 +130,8 @@
 
         ierr=nf90_open(cdr_file, nf90_nowrite, ncid)
         if(ierr/=0)
-     &      call handle_ierr(ierr,'init_cdr_frc:: Cant open cdr forcing file')
+     &      call handle_ierr(ierr,
+     &       'init_cdr_frc:: Cant open cdr forcing file')
 
         call ncread(ncid,cdr_loc_lon,cdr_lon)
         call ncread(ncid,cdr_loc_lat,cdr_lat)
@@ -174,9 +173,10 @@
             print *, 'at point', lmi
             print *, 'The intended release location was Lon:', cdr_lon(icdr), 'Lat:', cdr_lat(icdr)
             print *, 'The release will take place at Lon:', lonr(lmi(1),lmi(2)), 'Lat:', latr(lmi(1),lmi(2))
-            if ((rmask(lmi(1),lmi(2))==0) .and. (cdr_hsc(icdr) == 0)) then
-              error stop 'ERROR: single-point CDR release requested on a land point'
-            endif
+c$$$            if ((rmask(lmi(1),lmi(2))==0) .and. (cdr_hsc(icdr) == 0)) then
+c$$$              error stop
+c$$$     &           'ERROR: point CDR release requested on a land point'
+c$$$            endif
           endif
 
 
@@ -206,6 +206,24 @@
                 cidx = cidx+1
               endif
             endif
+            if (frac(lmi(1),lmi(2),icdr) ==1 ) then
+               if (rmask(lmi(1),lmi(2))==0) then
+                  print *, "release on dry point", icdr
+               elseif (rmask(lmi(1),lmi(2))==1) then
+                  print *, "release on wet point", icdr
+               end if
+            end if
+
+
+c$$$            end if
+c$$$            if ((rmask(lmi(1),lmi(2))==0) .and.
+c$$$     &           (frac(lmi(1),lmi(2),icdr) == 1)) then
+c$$$               print *, 'release on land:', icdr
+c$$$              !error stop 'ERROR: CDR release is on land.'
+c$$$            elseif (frac(lmi(1),lmi(2),icdr)==1) then
+c$$$               print *, 'release at sea', icdr
+c$$$            endif
+
 
           endif ! cdr_hsc(icdr) = 0
           cidx_start = cidx

--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -47,8 +47,6 @@
       character(len=11) :: cdr_vol_name = 'cdr_volume'!! stored in a forcing file
       character(len=11) :: cdr_trc_name = 'cdr_tracer'!! stored in a forcing file
       character(len=9)  :: cdr_tim_name = 'cdr_time'  !! stored in a forcing file
-!     character(len=5)  :: ncdr_dim_name = 'ncdr'      !! dimension name for number of cdrs in file
-!     character(len=8)  :: ntrc_dim_name = 'ntracers'   !! dimension name for number of tracers in file
 
 
       logical :: init_cdr_done = .false.
@@ -229,13 +227,6 @@
           end if
           call MPI_Barrier(MPI_COMM_WORLD, ierr)
        end if
-c$$$       if (any(bad_releases)) then
-c$$$          
-c$$$          print *, "ERROR the following CDR releases are on land",
-c$$$     &            pack([(i,i=1,ncdr)], bad_releases)
-c$$$          error stop
-c$$$       end if
-
             
 
         cdr_nprf = cidx

--- a/src/omega.F
+++ b/src/omega.F
@@ -43,7 +43,7 @@
       use scalars
 
       implicit none
-      integer istr,iend,jstr,jend, i,j,k
+      integer istr,iend,jstr,jend, i,j,k, icdr, cidx
       real CX(PRIVATE_1D_SCRATCH_ARRAY,0:N),  dtau, c2d,dh, cw, cff,
      &    wrk(PRIVATE_1D_SCRATCH_ARRAY),      cw_min,cw_max,cw_max2
       real, parameter :: cu_min=0.6D0, cu_max=1.0D0,

--- a/src/step2d_FB.F
+++ b/src/step2d_FB.F
@@ -39,7 +39,7 @@
       use mpi_exchanges
 
       implicit none
-      integer istr,iend,jstr,jend, i,j, kbak, kold
+      integer istr,iend,jstr,jend, i,j, kbak, kold, icdr, cidx
       real, dimension(PRIVATE_2D_SCRATCH_ARRAY) :: zeta_new, Dnew,
      &                         rubar,rvbar,  urhs,vrhs,  DUon,DVom,
      &                                       Drhs, UFx,UFe,VFx,VFe

--- a/src/step3d_t_ISO.F
+++ b/src/step3d_t_ISO.F
@@ -826,10 +826,6 @@ c**               cff=1./(z_r(i,j,k+1)-z_r(i,j,k))
           ! Loop over cdr release locations in this subdomain
           ! The global sum over all cdr_prf should be 1.
           ! cdr_flux unit is [C/s]
-c$$$           print *,"RANK",mynode,
-c$$$     &          "all CDR indices:", cdr_icdr(:), "NPRF", cdr_nprf
-c$$$           print *, "RANK",mynode,"SHAPE OF cdr_icdr:", SHAPE(cdr_icdr),
-c$$$     &          "CDR_NPRF", cdr_nprf
           do cidx=1,cdr_nprf
             icdr = cdr_icdr(cidx)
             i = cdr_iloc(cidx)

--- a/src/step3d_t_ISO.F
+++ b/src/step3d_t_ISO.F
@@ -40,7 +40,7 @@ c--# define CONST_TRACERS
 #  endif
 # endif
      &                                                             )
-      end
+      end subroutine step3d_t
 
       subroutine step3d_t_iso_tile( istr,iend,jstr,jend, WC,FC,CF,DC
      &                                                 ,  FX,FE, wrk1
@@ -55,7 +55,8 @@ c--# define CONST_TRACERS
 
       use param
       use pipe_frc
-      use cdr_frc
+      use cdr_frc, only: cdr_nprf, cdr_icdr,
+     &     cdr_source, cdr_iloc, cdr_jloc, cdr_flx, cdr_prf
       use river_frc
       use surf_flux, only: stflx, srflx
       use tracers
@@ -70,7 +71,7 @@ c--# define CONST_TRACERS
       use scalars
 
       implicit none
-      integer istr,iend,jstr,jend, imin,imax,jmin,jmax, i,j,k!, td
+      integer icdr, cidx, istr,iend,jstr,jend, imin,imax,jmin,jmax, i,j,k!, td
       real, dimension(PRIVATE_1D_SCRATCH_ARRAY,0:N) :: WC,FC,CF,DC
       real, dimension(PRIVATE_2D_SCRATCH_ARRAY)     :: FX,FE, wrk1
 # ifdef ADV_ISONEUTRAL
@@ -825,10 +826,17 @@ c**               cff=1./(z_r(i,j,k+1)-z_r(i,j,k))
           ! Loop over cdr release locations in this subdomain
           ! The global sum over all cdr_prf should be 1.
           ! cdr_flux unit is [C/s]
+c$$$           print *,"RANK",mynode,
+c$$$     &          "all CDR indices:", cdr_icdr(:), "NPRF", cdr_nprf
+c$$$           print *, "RANK",mynode,"SHAPE OF cdr_icdr:", SHAPE(cdr_icdr),
+c$$$     &          "CDR_NPRF", cdr_nprf
           do cidx=1,cdr_nprf
             icdr = cdr_icdr(cidx)
             i = cdr_iloc(cidx)
             j = cdr_jloc(cidx)
+            if (icdr==0) then
+               print *, "LOST AT LOCATION",mynode,i,j,cidx,cdr_nprf
+            end if
             do k=1,nz
               t(i,j,k,nnew,itrc)=t(i,j,k,nnew,itrc)
      &           +dt*pm(i,j)*pn(i,j)*
@@ -1094,7 +1102,7 @@ c??         enddo
         call exchange_xxx( t(:,:,:,nnew,nt) )
       endif
 # endif
-      end
+      end subroutine step3d_t_iso_tile
 
       subroutine check_step_t_switches(ierr)
 
@@ -1123,8 +1131,8 @@ c??         enddo
      &  'Insufficient length of string "cpps" in file "strings".',
      &        'Increase parameter "max_opt_size" it and recompile.'
       ierr=ierr+1
-      end
+      end subroutine check_step_t_switches
 #else
       subroutine step3d_t_empty
-      end
+      end subroutine step3d_t_empty
 #endif  /* SOLVE3D */


### PR DESCRIPTION
This PR fixes two main issues with the CDR implementation:

1. Checks for point releases on land were occurring too early. A later block for small, but nonzero, `hsc` values effectively treated them as point releases by setting `frac` to `1`, but the land check had already occurred, and only for `hsc==0`. As a result, on-land releases with small `hsc` were being missed. This PR adds a check for land points for all releases with `frac==1`, after all decisions relating to this have been made. It collects any land points it finds, adding them to a `bad_releases` array, so they can all be printed at once, rather than having the user fix them one at a time.
2. Index variables, particularly `icdr` and `cidx`, were being declared and used inconsistently:
 - `cdr_icdr` was declared as `real`, not `int`
 - `icdr` and `cidx` were declared as `public` in `cdr_frc.F` and then `use`-d by other modules (where they were not declared at all), despite being temporary local loop indices in all cases. This led to unpredictable and potentially incorrect array access logic throughout.
