### PR TITLE
Small BEC cleanup

### DIFF
--- a/src/bec2_vars.F
+++ b/src/bec2_vars.F
@@ -148,7 +148,6 @@ C
       character(len=40) tclm_name(NT) ! Taken from ETH code ncvars
 
 
-      public init_scalars_bec2
       contains
 !----------------------------------------------------------------------
 
@@ -184,61 +183,5 @@ C
 
       end subroutine init_arrays_bec2_vars  !]
 
-!----------------------------------------------------------------------
-      subroutine init_scalars_bec2()  ![
-!
-! Set initial values for  globally accessible (stored in common
-! blocks) scalar variables of the BEC model.
-!
-      use comm_vars
-      use scalars
-
-      implicit none
-      integer i,j, itrc ,lvar,lenstr ! ierr, DevinD removed ierr as arguement
-      integer omp_get_num_threads
-
-#ifdef SOLVE3D
-
-# ifdef BEC2_DIAG
-
-# endif /* BEC2_DIAG */
-
-      tclm_name(iPO4) = 'po4_time'
-      tclm_name(iNO3) = 'no3_time'
-      tclm_name(iSIO3) = 'sio3_time'
-      tclm_name(iO2) = 'o2_time'
-      tclm_name(iFE) = 'fe_time'
-      tclm_name(iDIC) = 'dic_time'
-      tclm_name(iALK) = 'alk_time'
-      tclm_name(iNH4) = 'nh4_time'
-      tclm_name(iDOC) = 'doc_time'
-      tclm_name(iDOP) = 'dop_time'
-      tclm_name(iDOP) = 'dop_time'
-      tclm_name(iDOPR) = 'dop_time'
-      tclm_name(iDON) = 'don_time'
-      tclm_name(iDONR) = 'don_time'
-      tclm_name(iDOFE) = 'dofe_time'
-      tclm_name(iSPC) = 'spc_time'
-      tclm_name(iSPCHL) = 'spchl_time'
-      tclm_name(iSPCACO3) = 'spcaco3_time'
-      tclm_name(iSPFE) = 'spfe_time'
-      tclm_name(iDIATC) = 'diatc_time'
-      tclm_name(iDIATCHL) = 'diatchl_time'
-      tclm_name(iDIATSI) = 'diatsi_time'
-      tclm_name(iDIATFE) = 'diatfe_time'
-      tclm_name(iZOOC) = 'zooc_time'
-      tclm_name(iDIAZC) = 'diazc_time'
-      tclm_name(iDIAZCHL) = 'diazchl_time'
-      tclm_name(iDIAZFE) = 'diazfe_time'
-# ifdef Ncycle_SY
-      tclm_name(iNO2) = 'no2_time'
-      tclm_name(iN2) = 'n2_time'
-      tclm_name(iN2O) = 'n2o_time'
-# endif
-#endif /* SOLVE3D */
-
-      end subroutine init_scalars_bec2  !]
-! ----------------------------------------------------------------------
-C
 #endif BIOLOGY_BEC2
       end module bec2_vars

--- a/src/init_scalars.F
+++ b/src/init_scalars.F
@@ -85,8 +85,4 @@ c      write(*,*) 'kmp_stacksize =', size
 
       endif
 
-#ifdef BIOLOGY_BEC2
-        call init_scalars_bec2
-#endif
-
       end

--- a/src/main.F
+++ b/src/main.F
@@ -30,16 +30,8 @@ C$    ierr=0
       tstart=MPI_Wtime()
       if (ierr == 0) then
 # endif
-#ifdef BIOLOGY_BEC2
-!     When using BEC, BGC tracer indices are set in init_tracers
-!     then used in init_scalars, so this order must be maintained
-         call init_tracers
-         call init_scalars(ierr)
-#else
         call init_scalars(ierr)          ! Initialize global scalars,
-                                         ! model tunable parameters,
         call init_tracers
-#endif
         if (ierr == 0) then
 C$        call omp_set_dynamic(.false.)
 C$OMP PARALLEL                           ! fast-time averaging weights
@@ -214,8 +206,6 @@ CR      write(*,*) ' -6' MYID
 #endif
 
 # if defined(BIOLOGY_BEC2)
-!     pH is initialized to 0 in ecosys_init
-!     FIXME: if using MARBL with diagnostics then this call is skipped and diagnostics arrays are not initialised to 0
       call ecosys2_init
 # endif /*BIOLOGY_BEC2*/
 


### PR DESCRIPTION
- Remove `init_scalars_bec2` subroutine and calls (unused - double-checked with Pierre)
- Simplify initialization logic in `main.F`: call order between `init_scalars` and `init_tracers` no longer depends on whether BEC is in use, which was breaking tests on the MPI masking branch and was also just plain ugly
- Remove stray comments in `main.F`

Let's double check the tests pass first but I'm fairly confident after diving into the commit history and chatting to Pierre that this is safe 🤞