### PR TITLE
Fix for exact restarts when restart and forcing times are nearly simultaneous

### DIFF
--- a/src/main.F
+++ b/src/main.F
@@ -238,9 +238,11 @@ CR      write(*,*) ' -6' MYID
 
                                   ! Set initial model clock: at this
       time=start_time             ! moment "start_time" (global scalar)
-      tdays=time*sec2day          ! is set by get_init or analytically
+                                  ! is set by get_init or analytically
                                   ! copy it into threadprivate "time"
+      tdays = (time-0.5*dt)*sec2day
       call set_forces
+      tdays = time*sec2day
       call set_depth(0)
 
 !----------------------------------------------------------------------


### PR DESCRIPTION
Sets "tdays" back by half a time step in the initialization, which should prevent set_forces from reading the wrong forcing record.