### PR TITLE
Fixed error reporting for river forcing.

### DIFF
--- a/src/get_init.F
+++ b/src/get_init.F
@@ -320,15 +320,19 @@ c--#define VERBOSE
       if (ierr == nf90_noerr) then
         call ncread(ncid,'riv_umask',riv_umask(1:i1,j0:j1),start)
       else
-        write(*,*) 'riv_umask not found in initial file. Initializing',
+        if (mynode == 0) then
+        write(*,*) 'riv_umask not found in initial file. Initializing ',
      & 'to zero.'
+        endif
       endif
       ierr=nf90_inq_varid(ncid, 'riv_vmask', varid)
       if (ierr == nf90_noerr) then
         call ncread(ncid,'riv_vmask',riv_vmask(i0:i1,1:j1),start)
       else
-        write(*,*) 'riv_vmask not found in initial file. Initializing',
+        if (mynode == 0) then
+        write(*,*) 'riv_vmask not found in initial file. Initializing ',
      & 'to zero.'
+        endif
       endif
 
 ! Free-surface and barotropic 2D momentuma, XI- and ETA-components

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -157,11 +157,13 @@
             call MPI_Reduce( local_maxval, global_maxval, 1, mpi_double_precision,
      &      mpi_max, 0, ocean_grid_comm, ierr)
 
-            if (global_maxval > nriv) then
-              write(*,*) 'ERROR: nriv=', nriv,
-     &       'but index ', global_maxval,
-     &       ' found in river input file.'
-              stop
+            if (mynode == 0) then
+              if (global_maxval > nriv) then
+                write(*,*) 'ERROR: nriv=', nriv,
+     &         'but index ', global_maxval,
+     &         ' found in river input file.'
+                error stop
+              endif
             endif
 
 !     Check for non-integer values


### PR DESCRIPTION
Changed code so only MPI rank 0 will report (was causing model to incorrectly fail, as other nodes would report bad values that had actually never been set).