### PR TITLE
Small fixes to upscaling output

### DIFF
--- a/src/upscale_output.F
+++ b/src/upscale_output.F
@@ -252,7 +252,7 @@
       integer, intent(in) :: itrc,k
       real, dimension(PRIVATE_2D_SCRATCH_ARRAY), intent(in) :: FX,FE
       integer, intent(in) :: istr, iend, jstr, jend
- 
+
       ! local
       integer :: i,j
 


### PR DESCRIPTION
Needed to add #ifdef clauses when it was calculating boundary fluxes,
    otherwise it would try to access a variable that had not been allocated.