### PR TITLE
Enable sst and sss corrections in bulk_frc.F

### DIFF
--- a/src/bulk_frc.F
+++ b/src/bulk_frc.F
@@ -771,35 +771,9 @@
 !          shflx_sen(i,j)=hfsen
 !          shflx_rlw(i,j)=hflw
 !
-!---------------------------------------------------------------
-! Flux correction to surface net heat flux.
-!---------------------------------------------------------------
-!
-!# ifdef QCORRECTION
-!          ! Not sure that this still works....
-!          cff=cff11*dqdtg(i,j,it11)+cff12*dqdtg(i,j,it12)
-!          stflx(i,j,itemp)=stflx(i,j,itemp) +cff*(
-!     &           t(i,j,N,nrhs,itemp) -cff13*sstg(i,j,it13)
-!     &                               -cff14*sstg(i,j,it14)
-!     &                                                  )
-!#  ifdef MASKING
-!     &                                           *rmask(i,j)
-!#  endif
-!# endif /* QCORRECTION */
-!
-!
 !--------------------------------------------------------------
 ! Flux corrections to surface net heat flux and salt flux.
 !--------------------------------------------------------------
-!# ifdef SFLX_CORR
-!# ifdef SALINITY
-!          stflx(i,j,isalt)=stflx(i,j,isalt) -dSSSdt*(
-!     &           t(i,j,N,nrhs,isalt) - sss(i,j)  )
-!#  ifdef MASKING
-!     &                                           *rmask(i,j)
-!#  endif
-!# endif
-!# endif
       call apply_surf_field_corr
 !---------------------------------------------------------------
 ! Restrict stflx to prevent surface temperature to go below -1.8

--- a/src/flux_frc.F
+++ b/src/flux_frc.F
@@ -90,14 +90,6 @@
         enddo
       enddo
 #endif
-!# if defined QCORRECTION
-!      do j=j0,j1
-!        do i=i0,i1
-!          stflx(i,j,itemp)=
-!     &       -dSSTdt*(t(i,j,nz,nrhs,itemp) - sst(i,j))
-!        enddo
-!      enddo
-!#endif
 
       ! 2a) set bottom heat flux: stflx(itemp)
 !     call set_frc_data(nc_bhflx,btflx(i0:i1,j0:j1,itemp),'r')
@@ -110,15 +102,7 @@
       call set_swflux
 #endif
 
-!#ifdef EXCHANGE
-!     call exchange_xxx(sustr,svstr)
-!     call exchange_xxx(srflx,stflx(:,:,itemp))
-!#ifdef SALINITY
-!     call exchange_xxx(stflx(:,:,isalt))
-!#endif
-!#endif
-!     srflx = 0
-!     print *,'maxval srflx: ', maxval(abs(srflx))
+      ! 5) Apply sst and sss corrections, if desired
       call apply_surf_field_corr
 
       end subroutine set_flux_frc  !]
@@ -139,14 +123,6 @@
         do i=i0,i1
           ! cm/day -> m/s
           stflx(i,j,isalt)=stflx(i,j,isalt)*t(i,j,N,nrhs,isalt)*cmday2ms
-!
-!! Add relaxation of surface salinity back to climatological value to
-!! avoid long-term drift.  Note that dSSSdt below is "piston velocity"
-!! expressed in [m/s].
-!# if defined SFLX_CORR
-!     &                 -dSSSdt*( t(i,j,N,nrhs,isalt)-sss(i,j) )
-!# endif
-!
         enddo
       enddo
 

--- a/src/surf_flux.F
+++ b/src/surf_flux.F
@@ -77,8 +77,8 @@
       implicit none
 
       ! local
-      allocate(  uwnd  (GLOBAL_2D_ARRAY)    );
-      allocate(  vwnd  (GLOBAL_2D_ARRAY)    );
+      allocate( uwnd  (GLOBAL_2D_ARRAY)     );
+      allocate( vwnd  (GLOBAL_2D_ARRAY)     );
       allocate( sustr  (GLOBAL_2D_ARRAY)    ); sustr=init
       allocate( sustr_r(GLOBAL_2D_ARRAY)    ); sustr_r=init
       allocate( svstr  (GLOBAL_2D_ARRAY)    ); svstr=init
@@ -131,6 +131,8 @@
       integer i,j
 
 #ifdef QCORRECTION && !defined ANA_SST
+! Add relaxation of sst back to climatological value to avoid long-
+! term drift. dSSTdt below is "piston velocity" expressed in [m/s].
       do j=j0,j1
         do i=i0,i1
           stflx(i,j,itemp)=


### PR DESCRIPTION
Previously the bulk_frc code was broken for the sst correction. This PR creates a new subroutine in surf_flux.F to unify the sst and sss corrections for both bulk and flux forcing.