### PR TITLE
Fix for exact restarts with CDR forcing.

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -470,15 +470,15 @@
                    ! prf = exp( - ((z-d)/vsc )^2)
                    if (cdr_vsc(icdr) == 0) then
                      do k=1,nz
-                       arg_nz(k) = abs(z_r(i,j,k) + cdr_dep(icdr))
+                       arg_nz(k) = abs(z_r0(i,j,k) + cdr_dep(icdr))
                      enddo
                        arg = minloc(arg_nz,1)
                        cdr_prf(cidx,:,arg) = frac(i,j,icdr)
                    else
                      vint = 0
                      do k=1,nz
-                       arg = ( (z_r(i,j,k) + cdr_dep(icdr) )/cdr_vsc(icdr) )**2
-                       cdr_prf(cidx,:,k) = exp(-arg)*Hz(i,j,k)
+                       arg = ( (z_r0(i,j,k) + cdr_dep(icdr) )/cdr_vsc(icdr) )**2
+                       cdr_prf(cidx,:,k) = exp(-arg)*Hz0(i,j,k)
                      enddo
                      ! The 1D integral of exp^(z/cdr_vsc(icdr))**2 is cdr_vsc(icdr)*SQRT(pi),
                      ! so normalizing by this amount will ensure we don't weight the

--- a/src/ocean_vars.F
+++ b/src/ocean_vars.F
@@ -47,6 +47,9 @@
       real,public,allocatable,dimension(:,:,:) :: Hz      ! height of rho-cell
       real,public,allocatable,dimension(:,:,:) :: z_r     ! depth at rho-points
       real,public,allocatable,dimension(:,:,:) :: z_w     ! depth at   w-points
+      real,public,allocatable,dimension(:,:,:) :: Hz0     ! height of rho-cell with zero SSH
+      real,public,allocatable,dimension(:,:,:) :: z_r0    ! depth at rho-points with zero SSH
+      real,public,allocatable,dimension(:,:,:) :: z_w0     ! depth at w-points with zero SSH
 # if defined NHMG || defined NONTRAD_COR
       real,public,allocatable,dimension(:,:,:) :: dzdxi
       real,public,allocatable,dimension(:,:,:) :: dzdeta
@@ -98,6 +101,9 @@
       allocate( Hz(GLOBAL_2D_ARRAY,N) )    ; Hz=init       ! height of rho-cell
       allocate( z_r(GLOBAL_2D_ARRAY,N) )   ; z_r=init      ! depth at rho-points
       allocate( z_w(GLOBAL_2D_ARRAY,0:N) ) ; z_w=init      ! depth at   w-points
+      allocate( Hz0(GLOBAL_2D_ARRAY,N) )   ; Hz0=init      ! height of rho-cell with zero SSH
+      allocate( z_r0(GLOBAL_2D_ARRAY,N) )  ; z_r0=init     ! depth at rho-points with zero SSH
+      allocate( z_w0(GLOBAL_2D_ARRAY,0:N) ); z_w0=init     ! depth at w-points with zero SSH
 # if defined NHMG || defined NONTRAD_COR
       allocate( dzdxi(GLOBAL_2D_ARRAY,1:N)  )
       allocate( dzdeta(GLOBAL_2D_ARRAY,1:N) )

--- a/src/set_depth.F
+++ b/src/set_depth.F
@@ -96,9 +96,38 @@
           enddo
         enddo
       enddo
+
+      ! Only set these during initialization
+      if (iic == 0) then
+        do j=jstrR,jendR
+          do i=istrR,iendR
+            z_w0(i,j,0)=-h(i,j)
+          enddo
+
+          do k=1,N,+1   !--> irreversible because of recursion in Hz
+
+            cff_w=hc*ds* dble(k-N)
+            cff_r=hc*ds*(dble(k-N)-0.5)
+
+            cff1_w=Cs_w(k)
+            cff1_r=Cs_r(k)
+
+            do i=istrR,iendR
+
+              z_w0(i,j,k)= h(i,j)*(cff_w+cff1_w*h(i,j))*hinv(i,j)
+
+              z_r0(i,j,k)= h(i,j)*(cff_r+cff1_r*h(i,j))*hinv(i,j)
+
+              Hz0(i,j,k)= z_w0(i,j,k)-z_w0(i,j,k-1)
+            enddo
+          enddo
+        enddo
+      endif
+
 # ifdef EXCHANGE
       if (iic == 0) then
         call exchange_xxx(hinv)
+              call exchange_xxx(z_w0,z_r0,Hz0)
       endif
       call exchange_xxx(z_w,z_r,Hz)
 # endif


### PR DESCRIPTION
For parameterized forcing the module was calculating how to distribute the forcing based on a vertical structure function that was calculated using the variable z_r. This implicitly used the SSH at the time of calculation, but since it is only calculated during model initialization this means that the vertical structure would be slightly different after any restart. This bugfix creates new depth/thickness variables that are calculated assuming zero SSH, which means that the CDR vertical structures will be the same regardless of when they are calculated.