### PR TITLE
Bugfix for cstar_output.

### DIFF
--- a/src/cstar_output.F
+++ b/src/cstar_output.F
@@ -16,7 +16,9 @@
       use scalars
       use ocean_vars
       use diagnostics
-      use cdr_frc
+      use cdr_frc, only: cdr_flx_3d_ALK, cdr_flx_3d_DIC, cdr_prf,
+     &                   cdr_flx, cdr_nprf, cdr_icdr, cdr_iloc,
+     &                   cdr_jloc, cdr_source, forcing_3d
       implicit none
 
       private


### PR DESCRIPTION
Was having a compile error because iALK and iDIC were defined in both cdr_frc and cstar_output.  Fixed this.