### PR TITLE
Fix bugs in error handling calls

### DIFF
--- a/src/basic_output.F
+++ b/src/basic_output.F
@@ -118,7 +118,7 @@
       character(len=200) :: error_info
 
       if (wrt_file_his .and. mod(output_period_his, dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_his (",
      &        output_period_his, ")"
@@ -129,7 +129,7 @@
       endif
 
       if (wrt_file_avg .and. mod(output_period_avg,dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_avg (",
      &        output_period_avg, ")"

--- a/src/bgc_io.F
+++ b/src/bgc_io.F
@@ -158,7 +158,7 @@
       logical,save           :: first_step_his=.true.
 
       if (wrt_his .and. mod(output_period_his, dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_his (",
      &        output_period_his, ")"
@@ -169,7 +169,7 @@
       endif
 
       if (wrt_avg .and. mod(output_period_avg,dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_avg (",
      &        output_period_avg, ")"
@@ -280,7 +280,7 @@
       logical,save           :: first_step_dia_his=.true.
 
       if (wrt_his_dia .and. mod(output_period_his_dia, dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_his_dia (",
      &        output_period_his_dia, ")"
@@ -291,7 +291,7 @@
       endif
 
       if (wrt_avg_dia .and. mod(output_period_avg_dia,dt) /= 0) then
-         write(error_info, '(A, F0.2, (2A), F0.2,A)')
+         write(error_info, *)
      &        "dt (", dt, ") is not a factor of ",
      &        "output_period_avg_dia (",
      &        output_period_avg_dia, ")"

--- a/src/check_switches2.F
+++ b/src/check_switches2.F
@@ -26,7 +26,7 @@
 
       if (isize<2) then
         ierr=ierr+1
-        write(error_info,'(1x,2A,I3,1x,A,I4,3x,A,I3,1x,A,2I4)')
+        write(error_info, *)
      &          'NSUB_X =', NSUB_X,  'is incompatible with Lm =', Lm,
      &       'i_X =', i_X,  '==> istr,iend =', istr,iend
 
@@ -37,7 +37,7 @@
       endif
       if (jsize<2) then
         ierr=ierr+1
-        write(error_info,'(1x,2A,I3,1x,A,I4,3x,A,I3,1x,A,2I4)')
+        write(error_info, *)
      &          'NSUB_E =', NSUB_E,  'is incompatible with Mm =', Mm,
      &       'j_E =', j_E,  '==> jstr,jend =', jstr,jend
          call handle_configuration_error(
@@ -178,7 +178,7 @@
       ncoupl=ncoupl+1
 #endif
       if (ncoupl==0) then
-        write(error_info,'(A)') 'neither PRED_COUPLED_MODE '//
+        write(error_info, *) 'neither PRED_COUPLED_MODE '//
      &                       'nor CORR_COUPLED_MODE are defined in '//
      &        '"set_global_definitions.h".'
         call handle_configuration_error(
@@ -187,7 +187,7 @@
 
         ierr=ierr+1
       elseif (ncoupl>1) then
-        write(error_info,'(A)')     'misconfigured '//
+        write(error_info, *)     'misconfigured '//
      &          'switches PRED_COUPLED_MODE and CORR_COUPLED_MODE '//
      &          'in "set_global_definitions.h": only one of them '//
      &        'should be defined.'
@@ -214,7 +214,7 @@
       nobc_east=nobc_east+1
 #endif
       if (nobc_west>1) then
-        write(error_info,'(A)') 'more than one '//
+        write(error_info, *) 'more than one '//
      &        'boundary condition is chosen on the WESTERN EDGE.'
          call handle_configuration_error(
      &        context=sr_name,
@@ -244,7 +244,7 @@
       nobc_north=nobc_north+1
 #endif
       if (nobc_south>1) then
-        write(error_info,'(A)') 'more than one '//
+        write(error_info, *) 'more than one '//
      &        'boundary condition is chosen on the SOUTHERN EDGE.'
          call handle_configuration_error(
      &        context=sr_name,
@@ -252,7 +252,7 @@
         ierr=ierr+1
       endif
       if (nobc_north>1) then
-        write(error_info,'(1x,2A)') 'more than one '//
+        write(error_info, *) 'more than one '//
      &        'boundary condition is chosen on the NORTHERN EDGE.'
          call handle_configuration_error(
      &        context=sr_name,
@@ -283,7 +283,7 @@
       nAk=nAk+1
 #endif
       if (nAk>1) then
-        write(error_info,'(A)') 'cppdefs.opt: more than '//
+        write(error_info, *) 'cppdefs.opt: more than '//
      &        'one vertical mixing scheme is chosen.'
         call handle_configuration_error(
      &        context=sr_name,
@@ -312,7 +312,7 @@
 
 #ifndef SOLVE3D
       if (ndtfast>1) then
-        write(error_info,'(A,I3,1x,A/12x,A,2x,A)')  'NDTFAST =',
+        write(error_info, *)  'NDTFAST =',
      &         ndtfast, 'is greater than unity for a shallow water',
      &        'configuration.','Change it to unity in startup file.'
       call handle_configuration_error(
@@ -322,7 +322,7 @@
       endif
 #endif
       return
-  99  mpi_master_only write(error_info,'(/1x,2A/14x,A)')
+  99  mpi_master_only write(error_info, *)
      &     'Insufficient size of string "cpps" ',
      &     'in file "strings".', 'Increase the size it and recompile.'
       call handle_configuration_error(

--- a/src/checkdims.F
+++ b/src/checkdims.F
@@ -137,7 +137,7 @@
               max_rec=dsize
             endif
           else
-             write(error_info,'(/A,I3/12x,3A/12x,A/)')
+             write(error_info,*)
      &            'Cannot get size of dimension #', id,
      &            'from netCDF file ''',fname(1:lname),'''.',
      &            nf90_strerror(ierr)
@@ -149,7 +149,7 @@
           endif
         enddo
       else
-        write(error_info,'(A)')
+        write(error_info,*)
      &          'Cannot get number of dimensions in netCDF file '''//
      &        fname(1:lname)// '''.'// nf90_strerror(ierr)
         call handle_configuration_error(
@@ -217,7 +217,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
             ierr=nf90_inquire_dimension(ncid, dimid(i), len=size)
             if (ierr == nf90_noerr) then
                if (count(i) /= size) then
-                  write(error_info,'(/A,I3,1x,5A,2(I5,1x,A)/)')
+                  write(error_info,*)
      &                    'mismatch in dimension #', i,
      &                    'for variable ''', vname(1:lvar), ''' in ''',
      &                     fname(1:lfnm),  ''': expecting',   count(i),
@@ -228,7 +228,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
                 ierr=nf90_noerr-1
               endif
             else
-              write(error_info,'(/A,I3,1x,6A/)')
+              write(error_info,*)
      &              'Cannot determine size of dimension #', i,
      &              'for variable ''', vname(1:lvar), ''' in ''',
      &              fname(1:lfnm), ''', ', nf90_strerror(ierr)
@@ -244,7 +244,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
           ierr=nf90_inquire_dimension(ncid, dimid(3), len=size)
           if (ierr == nf90_noerr) then
             if (n3 /= size) then
-              write(error_info,'(/5A,2(I4,1x,A)/)')
+              write(error_info,*)
      &                    'mismatch in dimension #3 of variable ''',
      &                        vname(1:lvar), ''' in ''', fname(1:lfnm),
      &              ''': expecting',n3,'instead of',size,'in the file.'
@@ -255,7 +255,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
               ierr=nf90_noerr-1
             endif
           else
-            write(error_info,'(/6A/)')
+            write(error_info,*)
      &            'Cannot determine size of dimension #3 for variable''',
      &            vname(1:lvar), ''' in ''', fname(1:lfnm), ''', ',
      &            nf90_strerror(ierr)
@@ -266,7 +266,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
           endif
         endif ! <-- n3 > 0
       else
-        write(error_info,'(/A,I3,1x,4A/)')
+        write(error_info,*)
      &      'Cannot make inquiry for variable varid =', varid, 'in ''',
      &        fname(1:lfnm), ''', ', nf90_strerror(ierr)
         call handle_configuration_error(
@@ -318,7 +318,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
       if (ierr == 0) then
         if (abs((hc-tst_val(1))/hc)>epsil) then
                 print *, hc,tst_val(1)
-          write(error_info,'(/A,F12.5,1x,A,F12.5,1x,3A/)')
+          write(error_info,*)
      &                  'Mismatch in ''hc'': should be', hc, 'found',
      &               tst_val(1), 'in file ''', fname(1:lfile), '''.'
           call handle_configuration_error(
@@ -341,7 +341,8 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
             endif
           enddo
           if (ierr /= 0) then
-            write(error_info,'(/4A/)')  'Mismatch in ''Cs_w'' ',
+            write(error_info,*)
+     &            'Mismatch in ''Cs_w'' ',
      &            'values in file ''', fname(1:lfile), '''.'
             call handle_configuration_error(
      &           context=fn_name,
@@ -364,7 +365,8 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
             endif
           enddo
           if (ierr /= 0) then
-            write(error_info,'(/1x,4A/)')  'Mismatch in ''Cs_r'' ',
+            write(error_info,*)
+     &            'Mismatch in ''Cs_r'' ',
      &            'values in file ''', fname(1:lfile), '''.'
             call handle_configuration_error(
      &           context=fn_name,
@@ -382,7 +384,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
         ierr=read_nc1dat(ncid, fname, 'theta_s', 1,  tst_val)
         if (ierr == 0) then
           if (abs(theta_s-tst_val(1)) > epsil) then
-            write(error_info,'(/2(A,F9.4,1x),3A/)')
+            write(error_info,*)
      &            'Mismatch in ''theta_s'': should be',   theta_s,
      &            'found',tst_val(1),'in file ''', fname(1:lfile),'''.'
             call handle_configuration_error(
@@ -397,7 +399,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
         ierr=read_nc1dat(ncid, fname, 'theta_b', 1,  tst_val)
         if (ierr == 0) then
           if (abs(theta_b-tst_val(1)) > epsil) then
-            write(error_info,'(/2(A,F9.4,1x),3A/)')
+            write(error_info,*)
      &      'Mismatch in ''theta_b'': should be',   theta_b, 'found',
      &            tst_val(1), 'in file ''', fname(1:lfile), '''.'
             call handle_configuration_error(
@@ -462,7 +464,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
         if (size == nlen) then
           ierr=nf90_get_att(ncid, nf90_global, vname, value)
           if (ierr /= nf90_noerr) then
-            write(error_info,'(/5A/12x,A/)')
+            write(error_info,*)
      &          'Cannot retrieve global attribute ''',   vname(1:lvar),
      &            ''' from ''', fname(1:lfile), '''.', nf90_strerror(ierr)
             call handle_configuration_error(
@@ -491,7 +493,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
                   endif
                 enddo
                 if (ierr /= nf90_noerr) then
-                  write(error_info,'(/A,I3,1x,3A/12x,A/)')
+                  write(error_info,*)
      &                'read_nc1dat :: Cannot find size of dimension #',
      &                 dimids(i),  'in file ''', fname(1:lfile), '''.',
      &                  nf90_strerror(ierr)
@@ -500,7 +502,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
      &                 info=error_info)
                 endif
               else
-                write(error_info,'(/5A/12x,A/)')
+                write(error_info,*)
      &                'Cannot determine dimension IDs for ''', vname(1:lvar),
      &                ''' in file ''', fname(1:lfile), '''.', nf90_strerror(ierr)
                 call handle_configuration_error(
@@ -509,7 +511,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
               endif
             endif
           else
-            write(error_info,'(/5A/12x,A/)')
+            write(error_info,*)
      &            'Cannot determine number of dimensions for ''', vname(1:lvar),
      &            ''' in file ''',  fname(1:lfile), '''.', nf90_strerror(ierr)
             call handle_configuration_error(
@@ -519,7 +521,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
           if (size == nlen .and. ierr == nf90_noerr) then
             ierr=nf90_get_var(ncid, varid, value)
             if (ierr/=nf90_noerr) then
-              write(error_info,'(/5A/12x,A/)')
+              write(error_info,*)
      &              'Cannot read variable ''',  vname(1:lvar),
      &              ''' from file ''', fname(1:lfile), '''.', nf90_strerror(ierr)
               call handle_configuration_error(
@@ -535,7 +537,7 @@ c$$$     &                            ''': must be', i5,1x, 'instead.'/)
         endif
       endif
       if (size /= nlen .and. ierr == nf90_noerr) then
-        write(error_info,'(/5A/12x,A,I7,1x,A,I7/)')
+        write(error_info,*)
      &        'Unexpected size of ''', vname(1:lvar),
      &        ''' in file ''',  fname(1:lfile),  ''':', 'should be',
      &        nlen, 'but found', size

--- a/src/get_init.F
+++ b/src/get_init.F
@@ -84,7 +84,7 @@ c--#define VERBOSE
               if (req_rec <= max_rec) then
                 record=req_rec
               else
-                write(error_info,'(/1x,2A,I4,1x,A/12x,A,I4,1x,3A/)')
+                write(error_info, *)
      &              'requested restart time ',
      &              'record',req_rec, 'exceeds number', 'of records',
      &                       max_rec,  'available in netCDF file ''',
@@ -102,7 +102,7 @@ c--#define VERBOSE
           endif
         endif
       else
-        write(error_info,'(/1x,4A/12x/)')
+        write(error_info, *)
      &        'Cannot open netCDF file ''', trim(ininame), '''.'
          call handle_netcdf_error(
      &        netcdf_status=ierr,
@@ -210,7 +210,7 @@ c--#define VERBOSE
       elseif (vname(3,indxTime)(1:3) == 'day') then
         time_scale=day2sec
       else
-        write(error_info,'(/1x,3A/12x,3A/)')
+        write(error_info, *)
      &  'unknown units for variable ''',trim(vname(1,indxTime)),
      &        '''', 'in netCDF file ''', trim(ininame), '''.'
         call handle_configuration_error(

--- a/src/grid.F
+++ b/src/grid.F
@@ -446,7 +446,7 @@
      &       info="Cause of termination: netCDF input.")
         end if
       else
-         write(error_info,'(/1x,4A/12x)')  'Cannot ',
+         write(error_info, *)  'Cannot ',
      &        'open input NetCDF file ''', trim(grdname), '''.'
          call handle_netcdf_error(
      &        netcdf_status=ierr,
@@ -460,7 +460,7 @@
       if (ierr == nf90_noerr) then
         ierr=nf90_get_var(ncid, varid, char1)
         if (ierr /= nf90_noerr) then
-           write(error_info, '(/,1X,5A,/,12X/)')
+           write(error_info, *)
      &          "Cannot read variable ",
      &          "'spherical'",
      &          " from netCDF file ",
@@ -473,7 +473,7 @@
         end if
 
       else
-         write(error_info,'(/1x,5a/)')
+         write(error_info, *)
      &        'Cannot find variable ''',
      &        'spherical',
      &        ''' within netCDF file ''',
@@ -489,7 +489,7 @@
 # ifdef SPHERICAL
         mpi_master_only write(*,'(/1x,A/)') 'Spherical grid detected.'
 # else
-        write(error_info,'(/1x,2A/24x,A/)')
+        write(error_info, *)
      &          'Spherical grid file detected, but CPP-switch',
      &                                 'SPHERICAL is not set.'
            call handle_configuration_error(
@@ -503,7 +503,7 @@
         if (ierr == nf90_noerr) then
           ierr=nf90_get_var(ncid, varid, xl)
           if (ierr /= nf90_noerr) then
-           write(error_info, '(/,1X,5A,/,12X/)')
+           write(error_info, *)
      &            "Cannot read variable ",
      &            "xl",
      &            " from netCDF file ",
@@ -515,7 +515,7 @@
      &          info=error_info)
           endif
        else
-         write(error_info,'(/1x,5a/)')
+         write(error_info, *)
      &        "Cannot find variable ",
      &         "'xl'",
      &         " within netCDF file ",
@@ -531,7 +531,7 @@
         if (ierr == nf90_noerr) then
           ierr=nf90_get_var(ncid, varid, el)
           if (ierr /= nf90_noerr) then
-           write(error_info, '(/,1X,5A,/,12X/)')
+           write(error_info, *)
      &            "Cannot read variable ",
      &            "'el'",
      &            " from netCDF file ",
@@ -543,7 +543,7 @@
      &          info=error_info)
           endif
        else
-          write(error_info,'(/1x,5a/)')
+          write(error_info, *)
      &         "Cannot find variable ",
      &         "'el'",
      &         " within netCDF file ",
@@ -611,7 +611,7 @@
         endif
 #endif
       else
-        write(error_info,'(1x,3A/12x,A,1x,A,I4)'),
+        write(error_info, *),
      &                'Cannot close file ''', trim(grdname), '''.',
      &        nf90_strerror(ierr) MYID
         call handle_netcdf_error(

--- a/src/marbl_driver.F
+++ b/src/marbl_driver.F
@@ -245,7 +245,7 @@
      &                 " to end of file"
                end if
             else
-               write(error_info, '(3A, I0, A)')
+               write(error_info, *)
      &              "error reading MARBL settings file ",
      &              trim(marbl_namelist_fname)," (read status ",
      &              read_status, ")"
@@ -275,7 +275,7 @@
 
 !     Check that the number of tracers in MARBL_instance agrees with ROMS' ntrc_bio:
       if ( nt_marbl .ne. ntrc_bio ) then
-         write(error_info,'(7x,A,I4,A,I4,A,I4,A)')
+         write(error_info, *)
      &        'Allocated no. of MARBL tracers'
      &        ,ntrc_bio
      &        ,' does not match no. expected by MARBL: '
@@ -513,7 +513,7 @@
      &              " to end of file"
             end if
          else
-               write(error_info, '(3A, I0, A)')
+               write(error_info, *)
      &              "error reading MARBL tracer list file ",
      &              trim(marbl_tracer_list_fname)," (read status ",
      &           read_status, ")"
@@ -596,7 +596,7 @@
 
 !     Throw error if counts don't match
             if (nr_marbl_ss_2d/=nr_marbl_ss_2d_check) then
-               write(error_info,'(7x,A,I4,A,I4,A)')
+               write(error_info, *)
      &              'Allocated no. of 2D marbl saved state vars '
      &              ,nr_marbl_ss_2d,
      &              ' does not match actual no. expected by MARBL: '
@@ -605,7 +605,7 @@
      &              context=module_name//"/"//sr_name,
      &              info=error_info)
             elseif (nr_marbl_ss_3d/=nr_marbl_ss_3d_check) then
-               write(error_info,'(7x,A,I4,A,I4,A)')
+               write(error_info, *)
      &              'Allocated no. of 3D marbl saved state vars '
      &              ,nr_marbl_ss_3d,
      &              ' does not match actual no. expected by MARBL: '
@@ -936,7 +936,7 @@
       if ( size(vname_marbl_diag_2d(1,:)) .ne.
      &     (diag_cnt_2d_tot) ) then
 
-         write(error_info,'(7x,A,I4,A,I4,A,I4,A)')
+         write(error_info, *)
      &        'Allocated no. of 2D BGC diagnostics: '
      &        ,size(vname_marbl_diag_2d(1,:))
      &        ,' does not match no. expected by MARBL: '
@@ -952,7 +952,7 @@
       elseif ( size(vname_marbl_diag_3d(1,:)) .ne.
      &        (diag_cnt_3d_tot) ) then
 
-         write(error_info,'(7x,A,I4,A,I4,A,I4,A)')
+         write(error_info, *)
      &        'Allocated no. of 3D BGC diagnostics: '
      &        ,size(vname_marbl_diag_3d(1,:))
      &        ,' does not match no. expected by MARBL: '
@@ -1146,7 +1146,7 @@
          end if
 
          if (.not. is_iostat_end(read_status)) then
-               write(error_info, '(3A, I0, A)')
+               write(error_info, *)
      &              "error reading MARBL diagnostic list file ",
      &              trim(marbl_diag_list_fname)," (read status ",
      &           read_status, ")"

--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -767,14 +767,14 @@
 
 
       if (.not. found_var_ever) then
-        write(error_info,'(/1x,3A/)')
+        write(error_info, *)
      &        'Could not find var: ', vname, 'in forcing files.'
         call handle_configuration_error(
      &       context=module_name//"/"//sr_name,
      &       info=error_info)   ! TODO maybe a more appropriate SR
       endif
       if (.not. found_rec) then
-         write(error_info,'(/1x,3A,I3/)')
+         write(error_info, *)
      &        'Ran out of time records for ',
      &        vname, ' mynode=', mynode
          call handle_configuration_error(
@@ -795,7 +795,7 @@
       endif ! Handle initital timestep.
 
       if (irec==0) then
-         write(error_info,'(/1x,3A,I3/)')
+         write(error_info, *)
      &  'First available forcing record is past current time for var: ',
      &        vname, ' mynode=', mynode
          call handle_configuration_error(
@@ -1513,7 +1513,7 @@
       end if
 
       if (trim(var_units) /= trim(file_var_units)) then
-        write(error_info,'(/3x,3A/5x,3A/)')
+        write(error_info, *)
      &   trim(file_var_units),' for var: ',
      &   trim(var_name),',  Units must be: ', trim(var_units)
         call handle_configuration_error(

--- a/src/tracers.F
+++ b/src/tracers.F
@@ -102,7 +102,7 @@
         else
 
           if(mynode==0) then
-             write(error_info,'(/1x,2A,I3,2A/)')
+             write(error_info, *)
      &            'Forcing type not supported: t_ana_frc(itrc)= ', t_ana_frc(itrc),
      &            ', for tracer: ', nc_t(itrc)%vname
             call handle_configuration_error(


### PR DESCRIPTION
The handle_X_error calls previously just used format strings that were carried over from the existing `write(*,` statements, but these caused EOF errors when the format string contained a record advance/newline (`/`) as `error_info` only has a single record.
This PR replaces format strings in 'write(error_info,<format>' with the generic 'write(error_info,*)' and leaves formatting up to the compiler for a quick fix, as the output is not meant to be parsed or structured rigidly, just read by a user.