### PR TITLE
Split pipe_flux -> pipe_fraction/pipe_index as with rivers

### DIFF
--- a/src/pipe_frc.F
+++ b/src/pipe_frc.F
@@ -27,7 +27,8 @@
       character(len=8) :: module_name = "pipe_frc"
       ! Variables used in the evolution equations
       integer,public  :: pidx ! Pipe index for looping through pipes
-      integer,public,allocatable,dimension(:,:) :: pipe_idx      ! pipe indices at grid points
+      integer,public,allocatable,dimension(:,:) :: pipe_idx ! pipe indices at grid points
+      real   ,public,allocatable,dimension(:,:) :: pidx_real ! Pipe indices (read as real by ncread)
       real   ,public,allocatable,dimension(:,:) :: pipe_fraction ! pipe fractional flux at grid points
       real   ,public,allocatable,dimension(:,:) :: pipe_flx      ! pipe flux
       real   ,public, dimension(npip,N)         :: pipe_prf      ! Pipe vertical profile
@@ -61,9 +62,6 @@
 
       ! local
       integer :: i,j
-
-      if (.not. init_pipe_done) call init_pipe_frc
-
       if (p_analytical) then                                ! Set pipe flux volumes and tracer data
 
         call set_ana_pipe_frc
@@ -76,15 +74,9 @@
 
         call set_pipe_vert_prf                             ! set pipe vertical profiles
 
-        do j = 1,ny                                        ! calculate fluxes with time interpolated volumes and conc.:
-          do i = 1,nx
-            if (pipe_idx(i,j) > 0.) then
-              pipe_flx(i,j)=pipe_fraction(i,j)*pipe_vol( pipe_idx(i,j) )
-            endif
-          enddo
-        enddo
-
       endif
+
+      if (.not. init_pipe_done) call init_pipe_frc
 
       end subroutine set_pipe_frc !]
 ! ----------------------------------------------------------------------
@@ -96,40 +88,100 @@
       ! Realistic case - stored as one value in NetCDF file where
       ! pipe grid point value = pidx + pipe_fraction
 
-      use netcdf, only: nf90_nowrite, nf90_open
+      use netcdf, only:
+     &     nf90_nowrite, nf90_open,
+     &     nf90_close, nf90_noerr, nf90_inq_varid
+      use param, only: ocean_grid_comm
+      use mpi, only: mpi_double_precision, mpi_max
+      use roms_read_write, only: frcfile
+      use error_handling, only: handle_configuration_error, handle_netcdf_error
+
       implicit none
       character(len=13) :: sr_name = "init_pipe_frc"
+      real  :: local_maxval, global_maxval
+      character(len=200) :: error_info
       ! local
-      integer :: ierr,ncid,v_id,i,j
-
-
+      integer :: ierr,ncid,v_id,i,j,varid
       if (p_analytical) then
 
         ! pipe_flx is defined in ana_pipe_frc.h
 
-      else
+      else ! Look in pipe forcing file for index and fraction vars
+         ierr = nf90_open(frcfile(nc_pvol%ifile), nf90_nowrite, ncid)
+         ierr = nf90_inq_varid(ncid, "pipe_index", varid)
+         ierr = ierr * nf90_inq_varid(ncid, "pipe_fraction", varid)
 
+         if (ierr == nf90_noerr) then
+            call ncread(ncid, "pipe_index", pidx_real(i0:i1,j0:j1))
+            call ncread(ncid, "pipe_fraction", pipe_fraction(i0:i1,j0:j1))
+            ierr = nf90_close(ncid)
+
+            ! Check if any river indices are greater than the chosen
+            ! value for nriv, in which case we could get a segfault
+            local_maxval = MAXVAL(pidx_real)
+
+            ! Find global maximum
+            call MPI_Reduce( local_maxval, global_maxval, 1, mpi_double_precision,
+     &      mpi_max, 0, ocean_grid_comm, ierr)
+
+            if (mynode == 0) then
+               if (global_maxval > npip) then
+                  write(error_info,*) 'npipe=', npip,
+     &                 'but index ', global_maxval,
+     &                 ' found in pipe input file.'
+                  call handle_configuration_error(
+     &                 context=module_name//"/"//sr_name,
+     &                 info=error_info)
+              endif
+            endif
+
+!     Check for non-integer values
+            pipe_idx(i0:i1, j0:j1) = int(pidx_real(i0:i1, j0:j1))
+            if (any(abs(pidx_real(i0:i1,j0:j1) -
+     &           pipe_idx(i0:i1,j0:j1)) > 1.0e-6)) then
+            call handle_configuration_error(
+     &           context=module_name//"/"//sr_name,
+     &           info="pipe_index contains non-integers!")
+            endif
+         else ! if not in the forcing file, look for a single variable in the grid file
         ! Read 'pipe_flux' from grid file (Pipe_idx & pipe_fraction in one value)
-        ierr=nf90_open(grdname, nf90_nowrite, ncid)
+            ierr=nf90_open(grdname, nf90_nowrite, ncid)
         ! Temporarily store as pipe_fraction to avoid extra array,
         ! but value still pipe_idx + pipe_fraction
-        call ncread(ncid,pipe_flx_name, pipe_fraction(i0:i1,j0:j1))
-        if(ierr/=0) then
-           call handle_netcdf_error(netcdf_status=ierr,
-     &          info="pipe not in file!",
-     &          context=module_name//"/"//sr_name)
-        end if
-        ! Separate pipe_idx & pipe_fraction:
-        do j = 1,ny
+            call ncread(ncid,pipe_flx_name, pipe_fraction(i0:i1,j0:j1))
+            if(ierr/=0) then
+               ierr = nf90_close(ncid) ! close grid file
+               write(error_info,*)
+     &              'unable to find pipe index and fraction'//
+     &              ' either as separate variables '//
+     &              ' (pipe_index, pipe_fraction) in pipe '//
+     &              ' forcing file ('// trim(frcfile(nc_pvol%ifile)) //
+     &              ') or as a combined variable, '// trim(pipe_flx_name) //
+     &              ',  in grid (' // trim(grdname)//
+     &              ') file.'
+               call handle_netcdf_error(
+     &              netcdf_status=ierr,
+     &              context=module_name//"/"//sr_name,
+     &              info=error_info)
+            end if
+! Separate pipe_idx & pipe_fraction:
+            do j = 1,ny
+               do i = 1,nx
+! read in value = pidx + pipe_fraction = pipe_idx(i,j) + pipe_fraction(i,j)
+                  pipe_idx(i,j)=floor(pipe_fraction(i,j)-1e-5)
+                  pipe_fraction(i,j)=pipe_fraction(i,j)-pipe_idx(i,j)
+               enddo
+            enddo
+
+         endif ! ierr==nf90_noerr / index&fraction variables in forcing file
+        do j = 1,ny                                        ! calculate fluxes with time interpolated volumes and conc.:
           do i = 1,nx
-            ! read in value = pidx + pipe_fraction = pipe_idx(i,j) + pipe_fraction(i,j)
-            pipe_idx(i,j)=floor(pipe_fraction(i,j)-1e-5)
-            pipe_fraction(i,j)=pipe_fraction(i,j)-pipe_idx(i,j)
+            if (pipe_idx(i,j) > 0.) then
+              pipe_flx(i,j)=pipe_fraction(i,j)*pipe_vol( pipe_idx(i,j) )
+            endif
           enddo
         enddo
-
-      endif
-
+      end if ! p_analytical
       init_pipe_done = .true.
       if(mynode==0) write(*,'(/7x,A/)') 'pipe_frc: init pipe locations'
 
@@ -140,6 +192,7 @@
 
       character(len=30) :: string
       allocate( pipe_idx(GLOBAL_2D_ARRAY) );      pipe_idx=0.
+      allocate( pidx_real(GLOBAL_2D_ARRAY) );     pidx_real=0.
       allocate( pipe_fraction(GLOBAL_2D_ARRAY) ); pipe_fraction=0.
       allocate( pipe_flx(GLOBAL_2D_ARRAY) );      pipe_flx=0.
       allocate( pipe_trc(npip,nt) ) ;             pipe_trc=0.


### PR DESCRIPTION
This PR replicates what was done for river forcing previously: ROMS now looks first in the forcing file for `pipe_index` and `pipe_fraction` variables, before falling back to the (now deprecated) combined version `pipe_flux` in the grid file. 