### PR TITLE
remove MPI_Barrier and rank-based conditionals for print

### DIFF
--- a/src/error_handling.F
+++ b/src/error_handling.F
@@ -25,27 +25,19 @@
       character(len=*), intent(in), optional :: info
       character(len=5120) :: final_message
 
-!     Ensure all nodes wait for message above to be printed before any call abort:
-#ifdef MPI
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-#endif
-
-      ! Write on node 0 (all nodes will call in a global failure)
-      if (mynode==0) then
-         write(error_unit, '(A)') repeat('!', 34) // " ROMS ERROR " //
-     &        repeat('!',34)
+      write(error_unit, '(A)') repeat('!', 34) // " ROMS ERROR " //
+     &     repeat('!',34)
 
       ! For context line, want to pad left and right of message so things are aligned:
-         msglen  = len_trim(context)
-         total   = 80
-         leftpad  = (total - msglen - 2) / 2 ! integer division = floor
-         rightpad = total - msglen - 2 - leftpad ! whatever remains
+      msglen  = len_trim(context)
+      total   = 80
+      leftpad  = (total - msglen - 2) / 2 ! integer division = floor
+      rightpad = total - msglen - 2 - leftpad ! whatever remains
 
-         write(error_unit,'(A)') repeat('!', leftpad) //
-     &        ' ' // trim(context) // ' ' // repeat('!',rightpad)
-         if (present(info)) write(error_unit,'(A)') trim(info)
-         write(error_unit,'(A)') repeat('!', total)
-      endif
+      write(error_unit,'(A)') repeat('!', leftpad) //
+     &     ' ' // trim(context) // ' ' // repeat('!',rightpad)
+      if (present(info)) write(error_unit,'(A)') trim(info)
+      write(error_unit,'(A)') repeat('!', total)
 
 #ifdef MPI
       call MPI_Abort(MPI_COMM_WORLD, mynode, ierr)
@@ -63,30 +55,22 @@
       character(len=*), intent(in), optional :: info
       character(len=5120) :: final_message
 
-!     Ensure all nodes wait for message above to be printed before any call abort:
-#ifdef MPI
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-#endif
+      write(error_unit, '(A)') repeat('!', 34) // " ROMS ERROR " //
+     &     repeat('!',34)
 
-      ! Write on node 0 (all nodes will call in a global failure)
-      if (mynode==tile) then
-         write(error_unit, '(A)') repeat('!', 34) // " ROMS ERROR " //
-     &        repeat('!',34)
+! For context line, want to pad left and right of message so things are aligned:
+      msglen  = len_trim(context)
+      total   = 80
+      leftpad  = (total - msglen - 2) / 2 ! integer division = floor
+      rightpad = total - msglen - 2 - leftpad ! whatever remains
 
-      ! For context line, want to pad left and right of message so things are aligned:
-         msglen  = len_trim(context)
-         total   = 80
-         leftpad  = (total - msglen - 2) / 2 ! integer division = floor
-         rightpad = total - msglen - 2 - leftpad ! whatever remains
-
-         write(error_unit,'(A)') repeat('!', leftpad) //
-     &        ' ' // trim(context) // ' ' // repeat('!',rightpad)
-         if (present(info)) write(error_unit,'(A)') trim(info)
-         write(error_unit,'(A)') repeat('!', total)
-         write(error_unit, '(A,I0,A,I0,A)')" Location: tile=", tile,
-     &        ", i=",i,", j=",j,", k=",k
-         write(error_unit,'(A)') repeat('!', total)
-      endif
+      write(error_unit,'(A)') repeat('!', leftpad) //
+     &     ' ' // trim(context) // ' ' // repeat('!',rightpad)
+      if (present(info)) write(error_unit,'(A)') trim(info)
+      write(error_unit,'(A)') repeat('!', total)
+      write(error_unit, '(A,I0,A,I0,A)')" Location: tile=", tile,
+     &     ", i=",i,", j=",j,", k=",k
+      write(error_unit,'(A)') repeat('!', total)
 
 #ifdef MPI
       call MPI_Abort(MPI_COMM_WORLD, mynode, ierr)
@@ -108,31 +92,24 @@
       character(len=*), intent(in), optional :: info
       character(len=5120) :: final_message
 
-!     Ensure all nodes wait for message above to be printed before any call abort:
-#ifdef MPI
-      call MPI_Barrier(MPI_COMM_WORLD, ierr)
-#endif
 
-!     Write on node 0
-      if (mynode==0) then
-         write(error_unit, '(A)') repeat('!', 33) // " NETCDF ERROR " //
-     &        repeat('!',33)
+      write(error_unit, '(A)') repeat('!', 33) // " NETCDF ERROR " //
+     &     repeat('!',33)
 
 !     For context line, want to pad left and right of message so things are aligned:
-         msglen  = len_trim(context)
-         total   = 80
-         leftpad  = (total - msglen - 2) / 2 ! integer division = floor
-         rightpad = total - msglen - 2 - leftpad ! whatever remains
+      msglen  = len_trim(context)
+      total   = 80
+      leftpad  = (total - msglen - 2) / 2 ! integer division = floor
+      rightpad = total - msglen - 2 - leftpad ! whatever remains
 
-         write(error_unit,'(A)') repeat('!', leftpad) //
-     &        ' ' // trim(context) // ' ' // repeat('!',rightpad)
-         if (present(info)) write(error_unit,'(A)') trim(info)
-         write(error_unit,'(A)') repeat('!', total)
-         write(error_unit, '(A,I0)')" nf90 status code:", netcdf_status
-         write(error_unit, '(2A)') "nf90 error message: ",
-     &        nf90_strerror(netcdf_status)
-         write(error_unit, '(A)') repeat('!', total)
-      endif
+      write(error_unit,'(A)') repeat('!', leftpad) //
+     &     ' ' // trim(context) // ' ' // repeat('!',rightpad)
+      if (present(info)) write(error_unit,'(A)') trim(info)
+      write(error_unit,'(A)') repeat('!', total)
+      write(error_unit, '(A,I0)')" nf90 status code:", netcdf_status
+      write(error_unit, '(2A)') "nf90 error message: ",
+     &     nf90_strerror(netcdf_status)
+      write(error_unit, '(A)') repeat('!', total)
 
 #ifdef MPI
       call MPI_Abort(MPI_COMM_WORLD, mynode, ierr)


### PR DESCRIPTION
MARBL Errors were causing a hang at the MPI Barrier call. Have removed this and the conditional that only rank 0 prints. First rank to get to the error handling routine now wins - makes the print and calls abort.