### PR TITLE
Change all time variables in bulk_frc.opt to "time".

### DIFF
--- a/src/bulk_frc.opt
+++ b/src/bulk_frc.opt
@@ -13,13 +13,13 @@
       type (ncforce) :: nc_vwnd  = ncforce(vname='vwnd', tname='time' )  ! v-wind (input data in m/s at 10m)
       type (ncforce) :: nc_tair  = ncforce(vname='Tair', tname='time' )  ! Air temp (input data Degrees C at 2m)
       type (ncforce) :: nc_Q     = ncforce(vname='qair', tname='time' )  ! Q (Specific humidity (kg/kg)
-      type (ncforce) :: nc_prate = ncforce(vname='rain', tname='rad_time' )  ! Precipitation rate (cm/day)
-      type (ncforce) :: nc_lwrad = ncforce(vname='lwrad',tname='rad_time' )  ! Downward longwave radiation [W/m^2]
-      type (ncforce) :: nc_swrad = ncforce(vname='swrad',tname='rad_time' )  ! net shortwave radiation [W/m^2]
+      type (ncforce) :: nc_prate = ncforce(vname='rain', tname='time' )  ! Precipitation rate (cm/day)
+      type (ncforce) :: nc_lwrad = ncforce(vname='lwrad',tname='time' )  ! Downward longwave radiation [W/m^2]
+      type (ncforce) :: nc_swrad = ncforce(vname='swrad',tname='time' )  ! net shortwave radiation [W/m^2]
 
 #if defined TAU_CORRECTION
-      type (ncforce)  :: nc_taux = ncforce(vname='TauX_corr',tname='Taucorr_time'  )  ! The TAU_CORRECTION flag is used to active a correction term to
-      type (ncforce)  :: nc_tauy = ncforce(vname='TauY_corr',tname='Taucorr_time'  )  ! bring bulk force field closer to that of the measured data.
+      type (ncforce)  :: nc_taux = ncforce(vname='TauX_corr',tname='time'  )  ! The TAU_CORRECTION flag is used to active a correction term to
+      type (ncforce)  :: nc_tauy = ncforce(vname='TauY_corr',tname='time'  )  ! bring bulk force field closer to that of the measured data.
 #endif
 
       ! End of user inputs


### PR DESCRIPTION
A few variables previously had "rad_time" as their time variable, which was leading to confusion about the correct way to set up this package. We will probably always just use "time" in our forcing files.