### PR TITLE
Bugfix in roms_part.F (New-tools)

### DIFF
--- a/New-tools/roms_part.F
+++ b/New-tools/roms_part.F
@@ -1281,8 +1281,8 @@ c$$$            if (index(ncinfo%dims(ivar)%dimnames(3),'time')>0) then
         ierr = nf90_close(npid)
       endif
 
-      gnx = gdims(1)+2
-      gny = gdims(2)+2
+      gnx = gdims(1)
+      gny = gdims(2)
       nz  = gdims(3)
 
       if (mynode==0) then ! single node to create joined file


### PR DESCRIPTION
The New-tools ncjoin command was creating a combined grid with the wrong number of gridpoints. This was creating a half-halo of dead points around the east and north edges of the domain. This PR fixes this issue for simulations that use code that has MPI Masking (we should use the old ncjoin if the simulation is run with older code that lacks MPI Masking, regardless of whether we actually used it).