### PR TITLE
Relocate CDR forcing to wet points.

### DIFF
--- a/src/cdr_frc.F
+++ b/src/cdr_frc.F
@@ -370,15 +370,17 @@
          endif
         endif ! cdr_hsc(icdr) = 0
 
-        ! Check for releases on land
-        if ((frac(lmi(1),lmi(2),icdr) ==1 ) .and.
+        if (.not. relocate_to_wet_pts) then
+          ! Check for releases on land
+          if ((frac(lmi(1),lmi(2),icdr) ==1 ) .and.
      &       (rmask(lmi(1),lmi(2))==0)) then
-           write(error_info,'(A,I0,A))') "CDR release ",
+            write(error_info,'(A,I0,A))') "CDR release ",
      &          icdr," is on land."
-         call error_log%raise_global(
-     &     context=module_name//"/"//sr_name,
-     &     info=error_info)
-        end if
+            call error_log%raise_global(
+     &      context=module_name//"/"//sr_name,
+     &      info=error_info)
+          endif
+        endif
 
         cidx_start = cidx
       enddo                    ! icdr
@@ -584,6 +586,17 @@
           dist(i,j) = radius*dist(i,j);    !Haversine distance
         enddo
       enddo
+
+      if (relocate_to_wet_pts) then
+        do j=1,ny
+          do i=1,nx
+            if (rmask(i,j) == 0) then
+              dist(i,j) = 1.E8
+            endif
+          enddo
+        enddo
+      endif
+
       deallocate(dLon2)
       deallocate(dLat2)
 

--- a/src/cdr_frc.opt
+++ b/src/cdr_frc.opt
@@ -18,6 +18,11 @@
                                                                            ! interpolated in time between consecutive records; otherwise,
                                                                            ! forcing is held constant until the next record is reached
 
+      ! RELOCATE CDR FORCING TO NEAREST WET POINT?
+      logical                            :: relocate_to_wet_pts = .false.  ! If false, any depth profile or single-point parameterized
+                                                                           ! forcing that is centered on land will cause the model to
+                                                                           ! error out.  If true, the forcing will be relocated or
+                                                                           ! recentered to the nearest wet point.
 
       ! PARAMETERIZED VERTICAL PROFILES ********************************
       logical,parameter,public :: cdr_volume  = .false.  ! Set to .false. if you want a tracer flux but no added water.


### PR DESCRIPTION
Adds an option to move single-point releases to the nearest wet point when the release is on land, rather than having ROMS error out.