### PR TITLE
Add Best Practices section to documentation

### DIFF
--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -1,0 +1,13 @@
+Best Practices
+==============
+
+Model Output
+------------
+
+To avoid partial files, corrupt files and post-processing errors, we recommend adapting the following practice when setting output frequency of output files:
+
+Boundary data frequency, 'bry_time' (1800 seconds default), should always be divisble by the timestep.
+
+Restart file frequency should be equal to, or multiplier of history and diagnostics file frequency, including ext files when nesting. If your restart file frequency is daily, then history and ext file frequency should be daily as well.
+
+When joining  partial files (including using extract_data_join), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid comands like: 'ncjoin *.nc' which is prone to errors.

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -12,7 +12,7 @@ Restart output frequency should be equal to, or a multiplier of your history and
 
     output_period_rst = output_period_his * nrpf_his / a
 
-where ``a`` is a integer positive integer
+where ``a`` is a integer positive integer.
 
 When joining partial files (including using ``extract_data_join``), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid commands like::
 

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -6,8 +6,8 @@ Model Output
 
 To avoid partial files, corrupt files and post-processing errors, we recommend adapting the following practice when setting output frequency of output files:
 
-Boundary data frequency, 'bry_time' (1800 seconds default), should always be divisble by the timestep.
+Output frequency should always be divisble by the timestep. Note, if you are nesting and have set ´do_extract = .true.´ in ´extract_data.opt´, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (.ext). So your timestep should be divisible by 1800. 
 
-Restart file frequency should be equal to, or multiplier of history and diagnostics file frequency, including ext files when nesting. If your restart file frequency is daily, then history and ext file frequency should be daily as well.
+Restart output frequency should be equal to, or multiplier of your history and diagnostics output file frequency, including ´.ext´ files when nesting to avoid partial files. If your restart file frequency is daily, then you should have maximum one history/diagnostics/cstar file written out per 24 hours. So, for example for history files, set your restart output period so that ´output_period_rst´=´output_period_his´*´nrpf_his´ / a, where a is an integer of at least one.
 
 When joining  partial files (including using extract_data_join), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid comands like: 'ncjoin *.nc' which is prone to errors.

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -12,7 +12,7 @@ Restart output frequency should be equal to, or a multiplier of your history and
 
     output_period_rst = output_period_his * nrpf_his / a
 
-where ``a`` is a integer positive integer.
+where ``a`` is a positive integer.
 
 When joining partial files (including using ``extract_data_join``), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid commands like::
 

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -6,8 +6,16 @@ Model Output
 
 To avoid partial files, corrupt files and post-processing errors, we recommend adapting the following practice when setting output frequency of output files:
 
-Output frequency should always be divisble by the timestep. Note, if you are nesting and have set ´do_extract = .true.´ in ´extract_data.opt´, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (.ext). So your timestep should be divisible by 1800. 
+Output frequency should always be divisible by the timestep. Note, if you are nesting and have set ``do_extract = .true.`` in ``extract_data.opt``, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (``.ext``). So your timestep should be divisible by 1800. 
 
-Restart output frequency should be equal to, or multiplier of your history and diagnostics output file frequency, including ´.ext´ files when nesting to avoid partial files. If your restart file frequency is daily, then you should have maximum one history/diagnostics/cstar file written out per 24 hours. So, for example for history files, set your restart output period so that ´output_period_rst´=´output_period_his´*´nrpf_his´ / a, where a is an integer of at least one.
+Restart output frequency should be equal to, or a multiplier of your history and diagnostics output file frequency, including ``.ext`` files when nesting to avoid partial files. If your restart file frequency is daily, then you should have maximum one history/diagnostics/cstar file written out per 24 hours. So, for example for history files, set your restart output period so that::
 
-When joining  partial files (including using extract_data_join), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid comands like: 'ncjoin *.nc' which is prone to errors.
+    output_period_rst = output_period_his * nrpf_his / a
+
+where ``a`` is an integer of at least one.
+
+When joining partial files (including using ``extract_data_join``), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid commands like::
+
+    ncjoin *.nc
+
+which is prone to errors.

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -8,7 +8,7 @@ To avoid partial files, corrupt files and post-processing errors, we recommend a
 
 Output frequency should always be divisible by the timestep. Note, if you are nesting and have set ``do_extract = .true.`` in ``extract_data.opt``, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (``.ext``). So your timestep should be divisible by 1800. 
 
-Restart output frequency should be equal to, or a multiplier of your history and diagnostics output file frequency, including ``.ext`` files when nesting to avoid partial files. If your restart file frequency is daily, then you should have maximum one history/diagnostics/cstar file written out per 24 hours. So, for example for history files, set your restart output period so that::
+Restart output frequency should be equal to, or a multiplier of your history and diagnostics output file frequency, including ``.ext`` files when nesting to avoid partial files. If your restart file frequency is 24 hours, then you could have one history/diagnostics/cstar file written out per 24 hours (or 12, 6, 3 or 2 hours) without creating partial files. So, for example for history files, set your restart output period so that::
 
     output_period_rst = output_period_his * nrpf_his / a
 

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -12,7 +12,7 @@ Restart output frequency should be equal to, or a multiplier of your history and
 
     output_period_rst = output_period_his * nrpf_his / a
 
-where ``a`` is an integer of at least one.
+where ``a`` is a integer positive integer
 
 When joining partial files (including using ``extract_data_join``), we recommend reading in only one file at a time, to avoid post-processing errors. I.e. avoid commands like::
 

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -6,11 +6,11 @@ Model Output
 
 To avoid partial files, corrupt files and post-processing errors, we recommend adapting the following practice when setting output frequency of output files:
 
-Output frequency should always be divisible by the timestep. Note, if you are nesting and have set ``do_extract = .true.`` in ``extract_data.opt``, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (``.ext``). So your timestep should be divisible by 1800. 
+Output frequency should always be divisible by the timestep. Note, if you are nesting and have set ``do_extract = .true.`` in ``extract_data.opt``, your most frequent output is likely to be 1800 seconds, which is the default output frequency of boundary data (``.ext``). In that case, your timestep should be a factor of 1800.
 
 Restart output frequency should be equal to, or a multiplier of your history and diagnostics output file frequency, including ``.ext`` files when nesting to avoid partial files. If your restart file frequency is 24 hours, then you could have one history/diagnostics/cstar file written out per 24 hours (or 12, 6, 3 or 2 hours) without creating partial files. So, for example for history files, set your restart output period so that::
 
-    output_period_rst = output_period_his * nrpf_his / a
+    output_period_rst = (output_period_his * nrpf_his) / a
 
 where ``a`` is a positive integer.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,12 @@ Key technical information:
    Installing ROMS <installation/index>
 
 .. toctree::
+   :maxdepth: 2
+   :caption: Best Practices
+
+   Best Practices <best_practices>
+
+.. toctree::
    :maxdepth: 1
    :caption: References
 


### PR DESCRIPTION

Adds a new "Best Practices" section to the documentation with guidance on model output file frequency settings.

Changes:
Created docs/best_practices.rst with a "Model Output" subsection
Updated docs/index.rst to include the new section in the table of contents

Content:
Provides recommendations for:
Boundary data frequency (bry_time) divisibility with timestep
Restart file frequency alignment with history and diagnostics files
Best practices for joining partial files to avoid post-processing errors

Jira ticket:
https://cworthy.atlassian.net/jira/software/c/projects/CSD/boards/144/backlog?assignee=712020%3A8f6d61f1-5059-4ca1-be5b-5eee38c68439&selectedIssue=CSD-536 