### PR TITLE
Hardcoded nrpf_rst=2.

### DIFF
--- a/src/basic_output.F
+++ b/src/basic_output.F
@@ -86,7 +86,7 @@
       real    :: t_avg_ovars=0
       integer :: navg_ovars = 0                             ! number of samples in average
       character(len=max_name_size),public :: fname_rst                 ! restart filename needed by diagnostics
-      integer,public           :: rec_rst=nrpf_rst          ! current file output record needed by diags
+      integer,public         :: rec_rst=2          ! current file output record needed by diags
       integer                :: month_at_prev_timestep
       logical                :: write_another_step = .false.
 

--- a/src/ocean_vars.opt
+++ b/src/ocean_vars.opt
@@ -4,7 +4,6 @@
       logical,parameter :: wrt_file_rst      = .false.     ! t/f to write module history file
       real,parameter    :: output_period_rst = 2000        ! output period in seconds
       logical,parameter :: monthly_restarts = .false.      ! This overrides output_period
-      integer,parameter :: nrpf_rst          =  2          ! total recs per file
 
       logical,parameter :: wrt_file_his      = .false.     ! t/f to write module history file
       real,parameter    :: output_period_his = 100         ! output period in seconds


### PR DESCRIPTION
People no longer get the option to mess this up. This will no longer appear in the ocean_vars.opt file.

Closes #185 and #84 