### PR TITLE
Optional MPI sync in error handling module

### DIFF
--- a/src/error_handling_mod.F90
+++ b/src/error_handling_mod.F90
@@ -358,6 +358,7 @@ contains
           write(*,*) "WARNING: GATHER_ERRORS_ON_MAIN_RANK=.false. in error_handling_mod.F90. ", &
                "Some ranks may fail to report errors before abort. ",&
                "For a full error log, set to .true. and recompile."
+          call stop_timers()
           call MPI_Abort(ocean_grid_comm,1)
        end if !
     end if !GATHER_ERRORS_ON_MAIN_RANK


### PR DESCRIPTION
Adds a logical `GATHER_ERRORS_ON_MAIN_RANK` to `error_handling_mod.F90` (default `.false.`). 
If `.true.`, `error_log%abort_check` calls `MPI_Allreduce` to check whether any rank needs to abort, then pool all ranks' error log messages on rank 0 for printing _before_ `MPI_Abort`. Cleaner exit, but more overhead.
If `.false.` (default), any rank that needs to abort will do so immediately, without attempting to gather error log entries from other ranks first. Messier exit, but less overhead.

Closes #207 