### PR TITLE
add USEPIO checks throughout development Makedefs.inc

### DIFF
--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -146,8 +146,11 @@ endif
 	NETCDFC_INC=$(or $(shell nc-config --cflags), -I$(NETCDFHOME)include)
 	NETCDFC_LIB=$(or $(shell nc-config --libs),   -L$(NETCDFHOME)lib -lnetcdf)
 
+ifeq ($(USEPIO),true)
         PNETCDF_INC= -I$(PNETCDFHOME)include
         PNETCDF_LIB= -L$(PNETCDFHOME)lib -lpnetcdf
+endif
+
 # MARBL
 ifeq ($(USEMARBL),true)
     ifeq ($(COMPILER),gnu)
@@ -235,7 +238,9 @@ endif
 
 # Options to link to libraries & modules (NetCDF, etc):
         LCDF =  $(NETCDFF_LIB) $(NETCDFC_LIB)
+ifeq ($(USEPIO),true)
         LCDF +=  $(PNETCDF_LIB)
+endif
 ifeq ($(USEMARBL),true)
 	LCDF += $(MARBL_LIB)
 endif
@@ -243,7 +248,9 @@ ifeq ($(USENHMG),true)
 	LCDF += $(NHMG_LIB)
 endif
 	LCDF +=$(NETCDFF_INC) $(NETCDFC_INC)
+ifeq ($(USEPIO),true)
         LCDF +=$(PNETCDF_INC)
+endif
 ifeq ($(USEMARBL),true)
 	LCDF += $(MARBL_INC)
 endif

--- a/src/pio_config.h
+++ b/src/pio_config.h
@@ -26,7 +26,7 @@
 
 #define USE_VARD 0
 
-#define PIO_HAS_PAR_FILTERS 
+#define PIO_HAS_PAR_FILTERS
 /* Does netCDF support netCDF/HDF5 files? */
 #define HAVE_NETCDF4
 


### PR DESCRIPTION
Can't currently compile locally without additional `ifeq($(USEPIO),true)` in `Makedefs.inc` 