### PR TITLE
Namelist bugfixes

### DIFF
--- a/src/bulk_frc.F90
+++ b/src/bulk_frc.F90
@@ -71,8 +71,6 @@ contains
     character(len=512) :: msg = ""
     ! Read namelist
     call open_namelist_file(namelist_unit)
-    rewind(namelist_unit)
-
     read (unit=namelist_unit, nml=BULK_FRC_SETTINGS, iostat=ios, iomsg=msg)
 
     if (ios /= 0) then

--- a/src/calc_pflx_mod.F90
+++ b/src/calc_pflx_mod.F90
@@ -51,6 +51,7 @@ contains
     character(len=20) :: sr_name = "read_nml_pflx"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=CALC_PFLX_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/cdr_frc.F90
+++ b/src/cdr_frc.F90
@@ -179,6 +179,7 @@ contains
     character(len=17) :: sr_name = "read_nml_cdr_frc"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=CDR_FRC_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/cdr_output.F90
+++ b/src/cdr_output.F90
@@ -107,6 +107,7 @@ contains
     character(len=20) :: sr_name = "read_cdr_output_nml"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=CDR_OUTPUT_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/extract_data.F90
+++ b/src/extract_data.F90
@@ -216,6 +216,7 @@ contains
     character(len=17) :: sr_name = "read_nml_extract"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=EXTRACT_DATA_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/namelist.nml
+++ b/src/namelist.nml
@@ -432,14 +432,13 @@ diag_uv = .false.          ! Output momentum diagnostics
 diag_trc = .false.         ! Output tracer diagnostics
 output_period = 3600       ! Output frequency (s)
 nrpf = 4                   ! Number of records per output file
-code_check_mode = .false.  ! diagnostics in stdout formatted for code testing
 /
 
 &STDOUT_DIAG_SETTINGS
 !-----------------------------
 ! Previously set in `diag.opt`
 !-----------------------------
-code_check_mode = .false.
+code_check_mode = .false.  ! diagnostics in stdout formatted for code testing
 /
 
 

--- a/src/pipe_frc.F90
+++ b/src/pipe_frc.F90
@@ -70,6 +70,7 @@ contains
     character(len=14) :: sr_name = "read_nml_pipe"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=PIPE_FRC_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/river_frc.F90
+++ b/src/river_frc.F90
@@ -118,6 +118,7 @@ contains
     character(len=15) :: sr_name = "read_nml_river"
     ! Read namelist
     call open_namelist_file(namelist_unit)
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=RIVER_FRC_SETTINGS, iostat=ios)
     if (ios /= 0) then
       call error_log%raise_global(&

--- a/src/roms_read_write.F90
+++ b/src/roms_read_write.F90
@@ -238,6 +238,7 @@ contains
     mpi_master_only write(*,'(/1x,A)') trim(title)
 !==========================================================================================
 #ifndef ANA_INITIAL
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=INITIAL_CONDITIONS, iostat=ios, iomsg=msg)
 
     if (ios /= 0) then
@@ -273,6 +274,7 @@ contains
 
 #endif /*ANA_INITIAL*/
 !==========================================================================================
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=FORCING_FILES, iostat=ios, iomsg=msg)
 
     if (ios /= 0) then

--- a/src/surf_flux.F90
+++ b/src/surf_flux.F90
@@ -117,6 +117,7 @@ contains
     end if
 
 #if defined SFLX_CORR && defined SALINITY
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=SSS_CORRECTION, iostat=ios, iomsg=msg)
     if (ios /= 0) then
       call error_log%raise_global(&
@@ -129,6 +130,7 @@ contains
 #endif
 
 #ifdef QCORRECTION
+    rewind(namelist_unit)
     read (unit=namelist_unit, nml=SST_CORRECTION, iostat=ios, iomsg=msg)
     call error_log%raise_global(&
     &context = module_name//'/'//sr_name,&


### PR DESCRIPTION
- Removes extra `code_check_mode` in `$ROMS_ROOT/src/namelist.nml`
- Ensures each namelist read is preceded by a rewind

Closes #267 , #263 