### PR TITLE
Increase cdr_file string length

### DIFF
--- a/src/cdr_frc.F90
+++ b/src/cdr_frc.F90
@@ -34,7 +34,7 @@ module cdr_frc
   private
   character(len=7) :: module_name="cdr_frc"
   character(len=1024) :: error_info=""
-  character(len=128) :: cdr_file = 'cdr_release.nc'
+  character(len=256) :: cdr_file = 'cdr_release.nc'
   integer(kind=4),public :: ncdr_parm=0
 
   ! Forcing file settings:


### PR DESCRIPTION
C-Star makes really long absolute path names. Hopefully 256 is enough but maybe 512 is safer...