### PR TITLE
Fix MPI buffers

### DIFF
--- a/src/roms_mpi.F90
+++ b/src/roms_mpi.F90
@@ -942,6 +942,40 @@ contains
 
   end subroutine init_mpi_buffers !]
 !--------------------------------------------------------
+  subroutine grow_pair(sendbuf,recvbuf,needed) ![
+    ! Ensure a send/recv buffer pair can hold at least "needed" elements,
+    ! growing both (and preserving the already-packed send data) if not.
+    !
+    ! init_mpi_buffers sizes the buffers assuming a 3D exchange packs at
+    ! most 4*(nz+1) two-dimensional slices (<=4 arrays, each with <=nz+1
+    ! vertical levels). That assumption is violated when an exchanged 3D
+    ! array's third dimension is NOT vertical levels -- e.g. the tidal
+    ! arrays ztide_r/ztide_i(GLOBAL_2D_ARRAY,ntides). With a small N and a
+    ! larger ntides, 2*ntides slices can exceed the default allocation, so
+    ! grow on demand instead. Buffers are module-level, so once grown they
+    ! stay grown and this cost is paid at most once per direction.
+    implicit none
+    real(kind=8),allocatable,intent(inout) :: sendbuf(:),recvbuf(:)
+    integer(kind=4),intent(in) :: needed
+    real(kind=8),allocatable :: tmp(:)
+    integer(kind=4) :: oldsize
+
+    oldsize = size(sendbuf)
+    if (needed <= oldsize) return
+
+    allocate(tmp(needed))
+    tmp(1:oldsize) = sendbuf(1:oldsize)
+    call move_alloc(tmp,sendbuf)
+
+    ! recv buffer holds the neighbour's matching message (same size for a
+    ! regular decomposition); contents need not be preserved.
+    if (size(recvbuf) < needed) then
+      deallocate(recvbuf)
+      allocate(recvbuf(needed))
+    endif
+
+  end subroutine grow_pair !]
+!--------------------------------------------------------
   subroutine pack_buffers(A,nxl,nyl,nzl) ![
     implicit none
 
@@ -966,41 +1000,49 @@ contains
 ! Append buffers with data from the array to be send
 !----------------------------------------------
     if (p_w>=0) then
+      call grow_pair(sendW,recvW,szW+szEW)
       sendW(szW+1:szW+szEW) = reshape(A(1:hl,jl0:jl1,:),(/szEW/))
       szW = szW+szEW
     endif
 
     if (p_e>=0) then
+      call grow_pair(sendE,recvE,szE+szEW)
       sendE(szE+1:szE+szEW) = reshape(A(nxl+1-hl:nxl,jl0:jl1,:),(/szEW/))
       szE = szE+szEW
     endif
 
     if (p_s>=0) then
+      call grow_pair(sendS,recvS,szS+szNS)
       sendS(szS+1:szS+szNS) = reshape(A(il0:il1,1:hl,:),(/szNS/))
       szS = szS+szNS
     endif
 
     if (p_n>=0) then
+      call grow_pair(sendN,recvN,szN+szNS)
       sendN(szN+1:szN+szNS) = reshape(A(il0:il1,nyl+1-hl:nyl,:),(/szNS/))
       szN = szN+szNS
     endif
 
     if (p_sw>=0) then
+      call grow_pair(sendSW,recvSW,szSW+szCr)
       sendSW(szSW+1:szSW+szCr) = reshape(A(1:hl,1:hl,:),(/szCr/))
       szSW = szSW+szCr
     endif
 
     if (p_se>=0) then
+      call grow_pair(sendSE,recvSE,szSE+szCr)
       sendSE(szSE+1:szSE+szCr) = reshape(A(nxl+1-hl:nxl,1:hl,:),(/szCr/))
       szSE = szSE+szCr
     endif
 
     if (p_ne>=0) then
+      call grow_pair(sendNE,recvNE,szNE+szCr)
       sendNE(szNE+1:szNE+szCr) = reshape(A(nxl+1-hl:nxl,nyl+1-hl:nyl,:),(/szCr/))
       szNE = szNE+szCr
     endif
 
     if (p_nw>=0) then
+      call grow_pair(sendNW,recvNW,szNW+szCr)
       sendNW(szNW+1:szNW+szCr) = reshape(A(1:hl,nyl+1-hl:nyl,:),(/szCr/))
       szNW = szNW+szCr
     endif

--- a/src/roms_mpi.F90
+++ b/src/roms_mpi.F90
@@ -942,7 +942,7 @@ contains
 
   end subroutine init_mpi_buffers !]
 !--------------------------------------------------------
-  subroutine grow_pair(sendbuf,recvbuf,needed) ![
+  subroutine grow_buffers(sendbuf,recvbuf,needed) ![
     ! Ensure a send/recv buffer pair can hold at least "needed" elements,
     ! growing both (and preserving the already-packed send data) if not.
     !
@@ -974,7 +974,7 @@ contains
       allocate(recvbuf(needed))
     endif
 
-  end subroutine grow_pair !]
+  end subroutine grow_buffers !]
 !--------------------------------------------------------
   subroutine pack_buffers(A,nxl,nyl,nzl) ![
     implicit none
@@ -1000,49 +1000,49 @@ contains
 ! Append buffers with data from the array to be send
 !----------------------------------------------
     if (p_w>=0) then
-      call grow_pair(sendW,recvW,szW+szEW)
+      call grow_buffers(sendW,recvW,szW+szEW)
       sendW(szW+1:szW+szEW) = reshape(A(1:hl,jl0:jl1,:),(/szEW/))
       szW = szW+szEW
     endif
 
     if (p_e>=0) then
-      call grow_pair(sendE,recvE,szE+szEW)
+      call grow_buffers(sendE,recvE,szE+szEW)
       sendE(szE+1:szE+szEW) = reshape(A(nxl+1-hl:nxl,jl0:jl1,:),(/szEW/))
       szE = szE+szEW
     endif
 
     if (p_s>=0) then
-      call grow_pair(sendS,recvS,szS+szNS)
+      call grow_buffers(sendS,recvS,szS+szNS)
       sendS(szS+1:szS+szNS) = reshape(A(il0:il1,1:hl,:),(/szNS/))
       szS = szS+szNS
     endif
 
     if (p_n>=0) then
-      call grow_pair(sendN,recvN,szN+szNS)
+      call grow_buffers(sendN,recvN,szN+szNS)
       sendN(szN+1:szN+szNS) = reshape(A(il0:il1,nyl+1-hl:nyl,:),(/szNS/))
       szN = szN+szNS
     endif
 
     if (p_sw>=0) then
-      call grow_pair(sendSW,recvSW,szSW+szCr)
+      call grow_buffers(sendSW,recvSW,szSW+szCr)
       sendSW(szSW+1:szSW+szCr) = reshape(A(1:hl,1:hl,:),(/szCr/))
       szSW = szSW+szCr
     endif
 
     if (p_se>=0) then
-      call grow_pair(sendSE,recvSE,szSE+szCr)
+      call grow_buffers(sendSE,recvSE,szSE+szCr)
       sendSE(szSE+1:szSE+szCr) = reshape(A(nxl+1-hl:nxl,1:hl,:),(/szCr/))
       szSE = szSE+szCr
     endif
 
     if (p_ne>=0) then
-      call grow_pair(sendNE,recvNE,szNE+szCr)
+      call grow_buffers(sendNE,recvNE,szNE+szCr)
       sendNE(szNE+1:szNE+szCr) = reshape(A(nxl+1-hl:nxl,nyl+1-hl:nyl,:),(/szCr/))
       szNE = szNE+szCr
     endif
 
     if (p_nw>=0) then
-      call grow_pair(sendNW,recvNW,szNW+szCr)
+      call grow_buffers(sendNW,recvNW,szNW+szCr)
       sendNW(szNW+1:szNW+szCr) = reshape(A(1:hl,nyl+1-hl:nyl,:),(/szCr/))
       szNW = szNW+szCr
     endif


### PR DESCRIPTION
This fixes a seg-fault for small toy grids due to out-of-range memory on the MPI buffers.

Note that Claude diagnosed and proposed this fix. The reasoning seems sound, and my previously failing case now works, but we should check the code carefully.

Here is Claude's reasoning summary:


> Summary
> 
>   The bug was not a data-type issue and not a buffer-initialization-size mismatch in the way first suspected. It's a structural mismatch in the MPI halo-exchange buffer sizing,  exposed by your tiny test grid.
> 
>   What happens:
>   - init_mpi_buffers (in roms_mpi.F90) sizes the corner buffers as mxCr = 4·bf²·(nz+1). The 4 means "at most 4 arrays per exchange"; (nz+1) means "at most N+1 vertical slices  per array." So it assumes a single exchange packs ≤ 4·(N+1) 2D slices total.
>   - With N=3, that ceiling is 4·4 = 16 slices → mxCr = 64.
>   - tides.F90:390 calls exchange_xxx(ztide_r, ztide_i), where each array is (GLOBAL_2D_ARRAY, ntides) with ntides=15. Its third dimension is tidal constituents, not vertical levels. That exchange packs 2·15 = 30 slices into each corner buffer — szCr reaches 4·30 = 120, overflowing the 64-element buffer. Exactly the reported "Index '120' … range (64:1)". (The "sende" in the message is the truncated/misattributed name of the corner buffer sendSE at line 994.)
>   - On a normal grid (e.g. N=50), the ceiling 4·51=204 ≫ 30, so it never overflowed — which is why only the tiny case triggers it.
> 
>   The fix: I added a grow_pair helper and a capacity check before every send-buffer write in pack_buffers. The send/recv buffer pairs now grow on demand to fit whatever is actually being packed, regardless of whether the third dimension is vertical levels, tidal constituents, or anything else. Because the buffers are module-level allocatables,  they grow at most a couple of times then stay large, so the overhead amortizes to nothing.
