### PR TITLE
Fix np=1 case

### DIFF
--- a/src/roms_mpi.F90
+++ b/src/roms_mpi.F90
@@ -258,11 +258,12 @@ contains
     j0 = 1; j1 = ny
 
     ! Each physical boundary the tile touches adds one rho ghost column/
-    ! row. The additions are incremental (not "= nx+1") so a tile that is
-    ! both the first AND last in a direction -- i.e. NP_XI==1 or NP_ETA==1
-    ! -- correctly gets BOTH ghost points (xi_rho = nx+2 = LLm+2). u/v
-    ! points have one fewer point globally, so they only gain the east/
-    ! north extra and keep the absolute "= nx+1"/"= ny+1" form.
+    ! row. The additions are incremental so that a tile that is both
+    ! the first AND last in a direction (i.e. NP_XI==1 or NP_ETA==1)
+    ! gets both ghost points.
+
+    ! u/v points have one fewer point globally, so they only gain the
+    ! east/north extra and keep the absolute "= nx+1"/"= ny+1" form.
     xi_rho = nx
     xi_u   = nx
     if (inode.eq.0) then

--- a/src/roms_mpi.F90
+++ b/src/roms_mpi.F90
@@ -257,15 +257,21 @@ contains
     i0 = 1; i1 = nx
     j0 = 1; j1 = ny
 
+    ! Each physical boundary the tile touches adds one rho ghost column/
+    ! row. The additions are incremental (not "= nx+1") so a tile that is
+    ! both the first AND last in a direction -- i.e. NP_XI==1 or NP_ETA==1
+    ! -- correctly gets BOTH ghost points (xi_rho = nx+2 = LLm+2). u/v
+    ! points have one fewer point globally, so they only gain the east/
+    ! north extra and keep the absolute "= nx+1"/"= ny+1" form.
     xi_rho = nx
     xi_u   = nx
     if (inode.eq.0) then
       i0 = 0
-      xi_rho = nx+1
+      xi_rho = xi_rho+1
     endif
     if (inode.eq.npx-1) then
       i1 = nx+1
-      xi_rho = nx+1
+      xi_rho = xi_rho+1
       xi_u   = nx+1
     endif
 
@@ -273,11 +279,11 @@ contains
     eta_v   = ny
     if (jnode.eq.0) then
       j0=0
-      eta_rho = ny+1
+      eta_rho = eta_rho+1
     endif
     if (jnode.eq.npy-1) then
       j1=ny+1
-      eta_rho = ny+1
+      eta_rho = eta_rho+1
       eta_v   = ny+1
     endif
 


### PR DESCRIPTION
This fixes a bug where ROMS was calculating the wrong grid size for cases where NP = 1 in either direction, and erroring out during the pre-check.

Claude diagnosed the error and provided this fix. It seems reasonable, but is worth a close inspection.

>   This was indeed a halo-region off-by-one, exactly as you suspected — but on the I/O dimension expectation, not the exchange buffers.
> 
>   The 1-proc grid is LLm=6, MMm=2, so the correct global grid file has xi_rho = LLm+2 = 8, eta_rho = MMm+2 = 4. Your grid file is correct; the model was computing the wrong expected size and rejecting a valid file.
> 
>   In mpi_setup, the rho-grid dimensions were set with two independent if blocks:
> 
>   if (inode.eq.0)     xi_rho = nx+1   ! west boundary ghost column
>   if (inode.eq.npx-1) xi_rho = nx+1   ! east boundary ghost column  ← clobbers, not adds
> 
>   With NP_XI > 1, any tile touches at most one of those boundaries, so nx+1 is right. But with NP_XI = 1, the single tile is both the west and east boundary — it owns both ghost columns and needs nx+2. Because the second assignment overwrote rather than added, the model expected xi_rho = 7 instead of 8 (and eta_rho = 3 instead of 4 when NP_ETA 
>   = 1). Note the tile's own i0=0 … i1=nx+1 range already spanned all 8 points — so xi_rho was even inconsistent with its own index bounds. 
>   
>   The fix: made the boundary additions incremental (xi_rho = xi_rho + 1), so a tile that is simultaneously first and last in a direction gets both ghost points. xi_u/eta_v keep the absolute nx+1/ny+1 form because u/v points have one fewer point globally (no west/south ghost). For NP_XI/NP_ETA > 1 the result is bit-for-bit identical to before, so
>   your working 4-proc case is unaffected.
> 
