### PR TITLE
Declare nt in surf_flux.F

### DIFF
--- a/src/surf_flux.F
+++ b/src/surf_flux.F
@@ -16,7 +16,7 @@
       use netcdf, only:
      &     nf90_global, nf90_write, nf90_nofill,
      &     nf90_open, nf90_put_att, nf90_close, nf90_set_fill
-      use scalars, only: dt, iic, tdays, time
+      use scalars, only: dt, iic, nt, tdays, time
 
       implicit none
 


### PR DESCRIPTION
The .opt file provided by Forge declares:

```
integer, parameter :: rst2diag(nt) = [0,1,1,0,0,0,0,0,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
```

but this gets included before we declare `nt` in the module, and compiler barfs.