### PR TITLE
Add auto calculation of marbl_timestep_ratio.

### DIFF
--- a/src/marbl_driver.F90
+++ b/src/marbl_driver.F90
@@ -70,7 +70,8 @@ module marbl_driver
   integer(kind=4)                     :: idx            ! Looping variable
 
 !     MARBL config:
-  integer(kind=4), public :: marbl_timestep_ratio = 1
+  integer(kind=4), public :: marbl_timestep_ratio
+  real(kind=8), public :: marbl_timestep = 3600.0
   character(len=256), public :: marbl_config_file='marbl_in'
   character(len=32), public ::&
   &marbl_tracers_to_write(40) = ""
@@ -80,7 +81,7 @@ module marbl_driver
 #endif
 
   namelist /MARBL_BIOGEOCHEMISTRY_SETTINGS/ marbl_config_file,&
-  &marbl_timestep_ratio, marbl_tracers_to_write&
+  &marbl_timestep, marbl_tracers_to_write&
 #ifdef MARBL_DIAGS
   &, marbl_diagnostics_to_write
 #endif
@@ -438,6 +439,21 @@ contains
 !     5. Save carbonate system indices
 !     ---------------------------------------------------------
     call get_tracer_indices(t_vname)
+
+!     6. Set MARBL update frequency
+!     ---------------------------------------------------------
+      if (mod(marbl_timestep,dt) /= 0) then
+        write(error_info, *)&
+        &'The ROMS timestep'&
+        &,marbl_timestep&
+        &,' does not evenly divide the MARBL timestep '&
+        &,dt, '.'
+        call error_log%raise_global(&
+        &context=module_name//"/"//sr_name,&
+        &info=error_info)
+      else
+        marbl_timestep_ratio = int(marbl_timestep / dt)
+      endif
 
   end subroutine marbldrv_configure_tracers
 

--- a/src/marbl_driver.F90
+++ b/src/marbl_driver.F90
@@ -442,18 +442,18 @@ contains
 
 !     6. Set MARBL update frequency
 !     ---------------------------------------------------------
-      if (mod(marbl_timestep,dt) /= 0) then
-        write(error_info, *)&
-        &'The ROMS timestep'&
-        &,marbl_timestep&
-        &,' does not evenly divide the MARBL timestep '&
-        &,dt, '.'
-        call error_log%raise_global(&
-        &context=module_name//"/"//sr_name,&
-        &info=error_info)
-      else
-        marbl_timestep_ratio = int(marbl_timestep / dt)
-      endif
+
+    if (mynode==printnode) then
+      print *, 'The requested MARBL timestep is', marbl_timestep, '.'
+    end if
+
+    marbl_timestep_ratio = max(1,int(marbl_timestep / dt))
+    marbl_timestep = dt * marbl_timestep_ratio
+
+    if (mynode==printnode) then
+      print *, 'The ROMS timestep must divide the MARBL timestep evenly, ',&
+      &'so the timestep MARBL will actually use is ', marbl_timestep, ' seconds.'
+    end if
 
   end subroutine marbldrv_configure_tracers
 

--- a/src/marbl_driver.F90
+++ b/src/marbl_driver.F90
@@ -455,6 +455,16 @@ contains
       &'so the timestep MARBL will actually use is ', marbl_timestep, ' seconds.'
     end if
 
+    if (marbl_timestep > 10800.0) then
+      write(error_info, *)&
+        &"MARBL timestep is ", marbl_timestep,&
+        &", but the maximum allowable value ",&
+        &"is 10800.0."
+        call error_log%raise_global(&
+        &context=module_name//"/"//sr_name,&
+        &info=error_info)
+    endif
+
   end subroutine marbldrv_configure_tracers
 
 

--- a/src/namelist.nml
+++ b/src/namelist.nml
@@ -285,7 +285,7 @@ nrpf_avg_dia = 10           ! Number of time records per BGC diagnostics file
 marbl_config_file = "marbl_in"  ! MARBL configuration file
 marbl_tracers_to_write = ""     ! MARBL tracers to include in BGC output
 marbl_diagnostics_to_write = "" ! MARBL diagnostics to include in BGC output
-marbl_timestep_ratio = 1        ! If "N", solve BGC equations every N model steps
+marbl_timestep = 3600.0           ! If "N", solve BGC equations every N model steps
 /
 
 !================================================================================

--- a/tests/results/results_github_gnu.json
+++ b/tests/results/results_github_gnu.json
@@ -5,19 +5,19 @@
   },
   "bgc_real_marbl": {
     "physics": "401b553e34febb537e6f5d0999404b63cf267a8b806d01fd012048964bdb5b71",
-    "bgc": "14074f25e6a64654365728cf57c749a14828dda5e7eb7512aab61f8a943f41db"
+    "bgc": "84456b6f3d5f79d87b1c874a6d134ea07ed81e607ce27305f7249ddf2d3237fb"
   },
   "cdr_3d": {
     "physics": "6cad9df264263d2596fab2f029ebb4fdf179efb733579a342c77773c2ea94e24",
-    "bgc": "fb75449b27fb00b0b33cebbfec9e656fe967b94f0e9ba7a34210364b65b4c421"
+    "bgc": "7c6030204057b3698a552fa32772c39ec686950651964b5214d12eb7e3a6b584"
   },
   "cdr_dp": {
     "physics": "6cad9df264263d2596fab2f029ebb4fdf179efb733579a342c77773c2ea94e24",
-    "bgc": "a357d79b4e221eecec8ef9943286e52729fcd01c9390b7c58b4beb0e7ef9182b"
+    "bgc": "747f3480bcccfbf42456f1a9c71580e7668dc869d59b02c5b1fa6f31eeec3ee1"
   },
   "cdr_parameterized": {
     "physics": "6cad9df264263d2596fab2f029ebb4fdf179efb733579a342c77773c2ea94e24",
-    "bgc": "c0a0f1facd5f49ff905d78fc9dd58779ed1d3f305fdde9a548ec3c6a6460e53e"
+    "bgc": "d7bae63e8930f309c66a0ce87cb3ddb918abe71350901aab2fb745b23dda5175"
   },
   "filament": {
     "physics": "894152c5cd8299dbd043d20ae188f7b44569c1b226246c0dfa6f9aed96c8e714"

--- a/tests/results/results_github_ifx.json
+++ b/tests/results/results_github_ifx.json
@@ -5,19 +5,19 @@
   },
   "bgc_real_marbl": {
     "physics": "bf6ac4cb417cf44d289ac42d68729d4211df0edd4defbe22e2e2b150a010f49d",
-    "bgc": "8dd8c73c0934ae7306d84e4dbdbfaeac9abae5abac4175e9f36bb70c6369a784"
+    "bgc": "74d5458119b50c53692713d85377857db2d27a49e03078b1ba6c747349c7faee"
   },
   "cdr_3d": {
     "physics": "15e78f1a08498f07cd621f0ca28128c61f967ef25327d8ab3cbe8c6617bfa609",
-    "bgc": "d9f2657f15ba92a25c3d591793256fc2bd7e15d553e21dbcaea804332b9231bc"
+    "bgc": "ecbdae1805f814847e52c1319c5809b1272d5fc6d806bfd13eb3393b5697a370"
   },
   "cdr_dp": {
     "physics": "15e78f1a08498f07cd621f0ca28128c61f967ef25327d8ab3cbe8c6617bfa609",
-    "bgc": "e0f8511ee0de447204753eaa4171f70fca5ac3769e9157d3da8e1fc410db27c1"
+    "bgc": "53ba8a8ff1713213e0aa971718a53a0845e621a328bc1f4bdaf4fd87a5ba4c15"
   },
   "cdr_parameterized": {
     "physics": "15e78f1a08498f07cd621f0ca28128c61f967ef25327d8ab3cbe8c6617bfa609",
-    "bgc": "74c36ea4831da8ef7c7a323d547f9cdea301fa2aac15598996c54bbea146473a"
+    "bgc": "ebe11bf96edb36bb56505b7e698e932869350bef077fa597e64a71cbd4aec0b7"
   },
   "filament": {
     "physics": "7f3bca215bfebc1f7bbb982ef3d411d8d72a95d5fef7d4294e112e465b6e808b"


### PR DESCRIPTION
The marbl_timestep_ratio namelist param has been changed to marbl_timestep. The model will error out if the ROMS timestep does not divide the marbl_timestep evenly.